### PR TITLE
Nerf malf AI

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -310,7 +310,7 @@
 			candidates -= player
 
 /datum/dynamic_ruleset/midround/malf/execute()
-	if(!candidates || !candidates.len)
+	if(!candidates || !candidates.len || get_active_player_count(alive_check = 1, afk_check = 1, human_check = 0) < 10)
 		return FALSE
 	var/mob/living/silicon/ai/M = pick_n_take(candidates)
 	assigned += M.mind

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -24,12 +24,17 @@
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute()
 	. = ..()
 	var/num_traitors = antag_cap[indice_pop] * (scaled_times + 1)
+
+	if(mode.roundstart_pop_ready < 10)
+		restricted_roles.Add("AI")
+
 	for (var/i = 1 to num_traitors)
 		var/mob/M = pick_n_take(candidates)
 		assigned += M.mind
 		M.mind.special_role = ROLE_TRAITOR
 		M.mind.restricted_roles = restricted_roles
 		GLOB.pre_setup_antags += M.mind
+
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/traitor/rule_process()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -39,6 +39,9 @@
 	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
 		restricted_jobs += "Assistant"
 
+	if(num_players() < 10)
+		restricted_jobs += "AI"
+
 	var/num_traitors = 1
 
 	var/tsc = CONFIG_GET(number/traitor_scaling_coeff)


### PR DESCRIPTION
## O pull requeście
Od teraz malf AI działa tylko gdy jest więcej niż 10 graczy (żywych lub gotowych przy starcie gry).
## Changelog
- malf ai od 10 graczy w góre w trybach dynamic i traitor

