### PR TITLE
Dodanie dispenserów drone shelli do stacji

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21991,6 +21991,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/droneDispenser/snowflake,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "biO" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -104474,9 +104474,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dzK" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/toy/figure/roboticist,
 /obj/machinery/button/door{
 	id = "roboticsprivacy";
 	name = "Robotics Privacy Control";
@@ -104489,6 +104486,7 @@
 	pixel_y = 38
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/droneDispenser/snowflake,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dzL" = (
@@ -105938,6 +105936,7 @@
 /obj/item/assembly/flash/handheld/weak,
 /obj/item/assembly/flash/handheld/weak,
 /obj/effect/turf_decal/bot,
+/obj/item/toy/figure/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dCq" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -55993,6 +55993,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"ust" = (
+/obj/machinery/droneDispenser/snowflake,
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "utg" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -85932,7 +85936,7 @@ ajt
 ajt
 bmr
 ajp
-ajp
+ust
 aBm
 bmf
 aEA

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -22585,6 +22585,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/droneDispenser/snowflake,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "aHQ" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14141,8 +14141,8 @@
 	height = 5;
 	id = "mining_home";
 	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/box;
-	width = 7
+	width = 7;
+	roundstart_template = /datum/map_template/shuttle/mining/box
 	},
 /turf/open/space/basic,
 /area/space)
@@ -83725,6 +83725,11 @@
 	},
 /turf/closed/wall,
 /area/chapel/main)
+"jTJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/droneDispenser/snowflake,
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "jUn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -115821,7 +115826,7 @@ cEm
 cFf
 cFg
 cFh
-cHR
+jTJ
 cIL
 cJK
 cCq

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -31430,7 +31430,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/droneDispenser/snowflake,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bsX" = (

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1396,8 +1396,8 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	width = 9;
-	roundstart_template = /datum/map_template/shuttle/labour/box
+	roundstart_template = /datum/map_template/shuttle/labour/box;
+	width = 9
 	},
 /turf/open/space/basic,
 /area/space)
@@ -1408,8 +1408,8 @@
 	height = 15;
 	id = "arrivals_stationary";
 	name = "arrivals";
-	width = 7;
-	roundstart_template = /datum/map_template/shuttle/arrival/box
+	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	width = 7
 	},
 /turf/open/space/basic,
 /area/space)
@@ -2868,6 +2868,10 @@
 /obj/item/healthanalyzer/advanced,
 /turf/open/floor/plasteel,
 /area/medical/medbay)
+"UJ" = (
+/obj/machinery/droneDispenser/snowflake,
+/turf/open/floor/plasteel,
+/area/science)
 "Vg" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -6482,7 +6486,7 @@ bl
 zo
 ah
 Yy
-bD
+UJ
 XC
 gY
 jb

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -24,6 +24,7 @@
 	var/iron_cost = 1000
 	var/glass_cost = 1000
 	var/power_used = 1000
+	
 
 	var/mode = DRONE_READY
 	var/timer
@@ -80,8 +81,10 @@
 	dispense_type = /obj/item/drone_shell/snowflake
 	end_create_message = "dispenses a snowflake drone shell."
 	// Those holoprojectors aren't cheap
-	iron_cost = 2000
-	glass_cost = 2000
+	iron_cost = 10000
+	glass_cost = 10000
+	gold_cost = 500
+	copper_cost = 500
 	power_used = 2000
 	starting_amount = 10000
 

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -24,6 +24,8 @@
 	var/iron_cost = 1000
 	var/glass_cost = 1000
 	var/power_used = 1000
+	var/gold_cost = 0
+	var/copper_cost = 0
 	
 
 	var/mode = DRONE_READY
@@ -54,7 +56,7 @@
 	var/datum/component/material_container/materials = AddComponent(/datum/component/material_container, list(/datum/material/iron, /datum/material/glass), MINERAL_MATERIAL_AMOUNT * MAX_STACK_SIZE * 2, TRUE, /obj/item/stack)
 	materials.insert_amount_mat(starting_amount)
 	materials.precise_insertion = TRUE
-	using_materials = list(/datum/material/iron = iron_cost, /datum/material/glass = glass_cost)
+	using_materials = list(/datum/material/iron = iron_cost, /datum/material/glass = glass_cost, /datum/material/copper = copper_cost, /datum/material/gold = gold_cost)
 
 /obj/machinery/droneDispenser/preloaded
 	starting_amount = 5000

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -6,7 +6,7 @@
 //Drone hands
 
 
-/mob/living/simple_animal/drone/doUnEquip(obj/item/I, force, silent = FALSE)
+/mob/living/simple_animal/drone/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE)
 	if(..())
 		update_inv_hands()
 		if(I == head)


### PR DESCRIPTION
# O Pull Requeście
<!-- np zamyka jakiś issue, wtedy napisz "fixes #nn" gdzie nn to numer issue -->
Od teraz dispensery shelli dronów dostępne są w każdym pomieszczeniu robotyki.
## Changelog
:cl:
add: dispensery dronów na stacjach
/:cl:

<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
