### PR TITLE
Dodanie spalaczy do kostnic

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21422,11 +21422,18 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/machinery/button/crematorium{
+	id = krematoriumkost;
+	pixel_y = 25
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bhq" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/bodycontainer/crematorium{
+	id = krematoriumkost
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21423,7 +21423,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/button/crematorium{
-	id = krematoriumkost;
+	id = 2137;
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel/dark,
@@ -21433,7 +21433,7 @@
 	dir = 4
 	},
 /obj/structure/bodycontainer/crematorium{
-	id = krematoriumkost
+	id = 2137
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -106708,11 +106708,9 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dDQ" = (
+/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/bodycontainer/crematorium{
-	id = kremkost
-	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -107299,11 +107297,6 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "dEY" = (
-/obj/machinery/button/crematorium{
-	id = kremkost;
-	pixel_x = 25;
-	pixel_y = 5
-	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dFe" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -106708,9 +106708,11 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dDQ" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/bodycontainer/crematorium{
+	id = 2137
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -107297,6 +107299,11 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "dEY" = (
+/obj/machinery/button/crematorium{
+	id = 2137;
+	pixel_x = 25;
+	pixel_y = 5
+	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dFe" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -106711,7 +106711,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/bodycontainer/crematorium{
-	id = krematoriumkost
+	id = kremkost
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -107300,7 +107300,7 @@
 /area/medical/morgue)
 "dEY" = (
 /obj/machinery/button/crematorium{
-	id = krematoriumkost;
+	id = kremkost;
 	pixel_x = 25;
 	pixel_y = 5
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -106708,9 +106708,11 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dDQ" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/bodycontainer/crematorium{
+	id = krematoriumkost
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -107297,6 +107299,11 @@
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "dEY" = (
+/obj/machinery/button/crematorium{
+	id = krematoriumkost;
+	pixel_x = 25;
+	pixel_y = 5
+	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dFe" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14141,8 +14141,8 @@
 	height = 5;
 	id = "mining_home";
 	name = "mining shuttle bay";
-	width = 7;
-	roundstart_template = /datum/map_template/shuttle/mining/box
+	roundstart_template = /datum/map_template/shuttle/mining/box;
+	width = 7
 	},
 /turf/open/space/basic,
 /area/space)
@@ -67957,13 +67957,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 32
 	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/paper/guides/jobs/medical/morgue{
-	pixel_x = -4
+/obj/structure/bodycontainer/crematorium{
+	dir = 8;
+	id = krematoriumkost
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -68392,11 +68388,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cCY" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
 /obj/item/radio/intercom{
 	pixel_x = 29
+	},
+/obj/machinery/button/crematorium{
+	id = krematoriumkost;
+	pixel_x = 25;
+	pixel_y = -9
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -69006,7 +69004,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cEd" = (
-/obj/structure/table,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/morgue";
 	dir = 4;
@@ -69016,11 +69013,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/clothing/gloves/color/latex,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67959,7 +67959,7 @@
 	},
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
-	id = krematoriumkost
+	id = 2137
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -68392,7 +68392,7 @@
 	pixel_x = 29
 	},
 /obj/machinery/button/crematorium{
-	id = krematoriumkost;
+	id = 2137;
 	pixel_x = 25;
 	pixel_y = -9
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -29196,7 +29196,10 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "boD" = (
-/obj/item/ectoplasm,
+/obj/structure/bodycontainer/crematorium{
+	dir = 8;
+	id = krematoriumkost
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "boE" = (
@@ -54280,6 +54283,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"dfo" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/button/crematorium{
+	id = krematoriumkost;
+	pixel_x = -5;
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "dfr" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
@@ -93440,7 +93457,7 @@ blg
 bmr
 bnz
 boD
-bpH
+dfo
 biY
 bsE
 bue

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -29198,7 +29198,7 @@
 "boD" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
-	id = krematoriumkost
+	id = 2137
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -54291,7 +54291,7 @@
 	dir = 4
 	},
 /obj/machinery/button/crematorium{
-	id = krematoriumkost;
+	id = 2137;
 	pixel_x = -5;
 	pixel_y = -25
 	},


### PR DESCRIPTION
# O Pull Requeście
Dodaje spalacze do kostnic na mapach: boxstation, metastation, deltastation, pubbystation. Na kilostation raczej nie potrzeba ponieważ już jest spalacz obok kostnicy.
Fixes #218 

## Changelog
:cl:
add: Spalacze w kostnicach
/:cl:

<!-- nw to się nazywa chyba spalacze? -->
