### PR TITLE
Danie woźnemu insulów

### DIFF
--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -28,3 +28,4 @@
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/janitor
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
+	gloves = /obj/item/clothing/gloves/color/yellow


### PR DESCRIPTION
Aby woźny mógł naprawiać kable zjedzone przez myszy bez kradnięcia lub żebrania o insule
