### PR TITLE
Port protokołów replikacji nanitów

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2799,6 +2799,7 @@
 #include "code\modules\research\nanites\extra_settings\type.dm"
 #include "code\modules\research\nanites\nanite_programs\buffing.dm"
 #include "code\modules\research\nanites\nanite_programs\healing.dm"
+#include "code\modules\research\nanites\nanite_programs\protocols.dm"
 #include "code\modules\research\nanites\nanite_programs\rogue.dm"
 #include "code\modules\research\nanites\nanite_programs\sensor.dm"
 #include "code\modules\research\nanites\nanite_programs\suppression.dm"

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -532,3 +532,35 @@
 	id = "sensor_species_nanites"
 	program_type = /datum/nanite_program/sensor/species
 	category = list("Sensor Nanites")
+
+////////////////////NANITE PROTOCOLS//////////////////////////////////////
+//Note about the category name: The UI cuts the last 8 characters from the category name to remove the " Nanites" in the other categories
+//Because of this, Protocols was getting cut down to "P", so i had to add some padding
+/datum/design/nanites/kickstart
+	name = "Kickstart Protocol"
+	desc = "Replication Protocol: the nanites focus on early growth, heavily boosting replication rate for a few minutes after the initial implantation."
+	id = "kickstart_nanites"
+	program_type = /datum/nanite_program/protocol/kickstart
+	category = list("Protocols_Nanites")
+
+/datum/design/nanites/factory
+	name = "Factory Protocol"
+	desc = "Replication Protocol: the nanites build a factory matrix within the host, gradually increasing replication speed over time. The factory decays if the protocol is not active."
+	id = "factory_nanites"
+	program_type = /datum/nanite_program/protocol/factory
+	category = list("Protocols_Nanites")
+
+/datum/design/nanites/tinker
+	name = "Tinker Protocol"
+	desc = "Replication Protocol: the nanites learn to use metallic material in the host's bloodstream to speed up the replication process."
+	id = "tinker_nanites"
+	program_type = /datum/nanite_program/protocol/tinker
+	category = list("Protocols_Nanites")
+
+/datum/design/nanites/offline
+	name = "Offline Production Protocol"
+	desc = "Replication Protocol: while the host is asleep or otherwise unconcious, the nanites exploit the reduced interference to replicate more quickly."
+	id = "offline_nanites"
+	program_type = /datum/nanite_program/protocol/offline
+	category = list("Protocols_Nanites")
+	

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -291,3 +291,24 @@
 	if(kill_code && code == kill_code)
 		host_mob.investigate_log("'s [name] nanite program was deleted by [source] with code [code].", INVESTIGATE_NANITES)
 		qdel(src)
+
+///A nanite program containing a behaviour protocol. Only one protocol of each class can be active at once.
+/datum/nanite_program/protocol
+	name = "Nanite Protocol"
+	var/protocol_class = NONE
+
+/datum/nanite_program/protocol/check_conditions()
+	. = ..()
+	for(var/protocol in nanites.protocols)
+		var/datum/nanite_program/protocol/P = protocol
+		if(P != src && P.activated && P.protocol_class == protocol_class)
+			return FALSE
+
+/datum/nanite_program/protocol/on_add(datum/component/nanites/_nanites)
+	..()
+	nanites.protocols += src
+
+/datum/nanite_program/protocol/Destroy()
+	if(nanites)
+		nanites.protocols -= src
+	return ..()

--- a/code/modules/research/nanites/nanite_programs/protocols.dm
+++ b/code/modules/research/nanites/nanite_programs/protocols.dm
@@ -1,0 +1,105 @@
+//Replication Protocols
+/datum/nanite_program/protocol/kickstart
+	name = "Kickstart Protocol"
+	desc = "Replication Protocol: the nanites focus on early growth, heavily boosting replication rate for a few minutes after the initial implantation."
+	use_rate = 0
+	rogue_types = list(/datum/nanite_program/necrotic)
+	protocol_class = NANITE_PROTOCOL_REPLICATION
+	var/boost_duration = 1200
+
+/datum/nanite_program/protocol/kickstart/check_conditions()
+	if(!(world.time < nanites.start_time + boost_duration))
+		return FALSE
+	return ..()
+
+/datum/nanite_program/protocol/kickstart/active_effect()
+	nanites.adjust_nanites(null, 3.5)
+
+/datum/nanite_program/protocol/factory
+	name = "Factory Protocol"
+	desc = "Replication Protocol: the nanites build a factory matrix within the host, gradually increasing replication speed over time. \
+	The factory decays if the protocol is not active, or if the nanites are disrupted by shocks or EMPs."
+	use_rate = 0
+	rogue_types = list(/datum/nanite_program/necrotic)
+	protocol_class = NANITE_PROTOCOL_REPLICATION
+	var/factory_efficiency = 0
+	var/max_efficiency = 1000 //Goes up to 2 bonus regen per tick after 16 minutes and 40 seconds
+
+/datum/nanite_program/protocol/factory/on_process()
+	if(!activated || !check_conditions())
+		factory_efficiency = max(0, factory_efficiency - 5)
+	..()
+
+/datum/nanite_program/protocol/factory/on_emp(severity)
+	..()
+	factory_efficiency = max(0, factory_efficiency - 300)
+
+/datum/nanite_program/protocol/factory/on_shock(shock_damage)
+	..()
+	factory_efficiency = max(0, factory_efficiency - 200)
+
+/datum/nanite_program/protocol/factory/on_minor_shock()
+	..()
+	factory_efficiency = max(0, factory_efficiency - 100)
+
+/datum/nanite_program/protocol/factory/active_effect()
+	factory_efficiency = min(factory_efficiency + 1, max_efficiency)
+	nanites.adjust_nanites(null, round(0.002 * factory_efficiency, 0.1))
+
+/datum/nanite_program/protocol/tinker
+	name = "Tinker Protocol"
+	desc = "Replication Protocol: the nanites learn to use metallic material in the host's bloodstream to speed up the replication process."
+	use_rate = 0
+	rogue_types = list(/datum/nanite_program/necrotic)
+	protocol_class = NANITE_PROTOCOL_REPLICATION
+	var/boost = 2
+	var/list/valid_reagents = list(
+		/datum/reagent/iron,
+		/datum/reagent/copper,
+		/datum/reagent/gold,
+		/datum/reagent/silver,
+		/datum/reagent/mercury,
+		/datum/reagent/aluminium,
+		/datum/reagent/silicon)
+
+/datum/nanite_program/protocol/tinker/check_conditions()
+	if(!nanites.host_mob.reagents)
+		return FALSE
+
+	var/found_reagent = FALSE
+
+	var/datum/reagents/R = nanites.host_mob.reagents
+	for(var/VR in valid_reagents)
+		if(R.has_reagent(VR, 0.5))
+			R.remove_reagent(VR, 0.5)
+			found_reagent = TRUE
+			break
+	if(!found_reagent)
+		return FALSE
+	return ..()
+
+/datum/nanite_program/protocol/tinker/active_effect()
+	nanites.adjust_nanites(null, boost)
+
+/datum/nanite_program/protocol/offline
+	name = "Offline Production Protocol"
+	desc = "Replication Protocol: while the host is asleep or otherwise unconcious, the nanites exploit the reduced interference to replicate more quickly."
+	use_rate = 0
+	rogue_types = list(/datum/nanite_program/necrotic)
+	protocol_class = NANITE_PROTOCOL_REPLICATION
+	var/boost = 3
+
+/datum/nanite_program/protocol/offline/check_conditions()
+	var/is_offline = FALSE
+	if(nanites.host_mob.stat >= UNCONSCIOUS) //DEAD or UNCONSCIOUS
+		is_offline = TRUE
+	if(nanites.host_mob.InCritical() && !HAS_TRAIT(nanites.host_mob, TRAIT_NOSOFTCRIT))
+		is_offline = TRUE
+	if(nanites.host_mob.InFullCritical() && !HAS_TRAIT(nanites.host_mob, TRAIT_NOHARDCRIT))
+		is_offline = TRUE
+	if(!is_offline)
+		return FALSE
+	return ..()
+
+/datum/nanite_program/protocol/offline/active_effect()
+	nanites.adjust_nanites(null, boost)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1075,6 +1075,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 15000
 
+/datum/techweb_node/nanite_replication_protocols
+	id = "nanite_replication_protocols"
+	display_name = "Nanite Replication Protocols"
+	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
+	prereq_ids = list("nanite_harmonic")
+	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	export_price = 12500
+
 ////////////////////////Alien technology////////////////////////
 /datum/techweb_node/alientech //AYYYYYYYYLMAOO tech
 	id = "alientech"


### PR DESCRIPTION
# O Pull Requeście
Dodaje protokoły replikacji nanitów z tg, dostępne teraz do odkrycia za 7500 punktów po odkryciu harmoniców

## Changelog
:cl:
add: przeportowano protokoły replikacji nanitów z tg
/:cl:

<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
