### PR TITLE
Polskie znaki prawidłowo wyświetlające się w książkach

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -204,7 +204,7 @@
 	if(!user.can_read(src))
 		return
 	if(dat)
-		user << browse("<TT><I>Penned by [author].</I></TT> <BR>" + "[dat]", "window=book[window_size != null ? ";size=[window_size]" : ""]")
+		user << browse("<TT><I>Penned by [author].</I></TT> <BR>" + "<HTML><HEAD><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'></HEAD><BODY>[dat]</BODY></HTML>", "window=book[window_size != null ? ";size=[window_size]" : ""]")
 		user.visible_message("[user] opens a book titled \"[title]\" and begins reading intently.")
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "book_nerd", /datum/mood_event/book_nerd)
 		onclose(user, "book")


### PR DESCRIPTION
# O Pull Requeście
<!-- np zamyka jakiś issue, wtedy napisz "fixes #nn" gdzie nn to numer issue -->
Od teraz polskie znaki powinny się prawidłowo wyświetlać w książkach. Pozostaje jeszcze kwestia tytułów, które wciąż polskich znaków nie mogą mieć, ale tym trzeba by się zająć przy okazji naprawienia ogólnego wprowadzania polskich znaków w niektóre miejsca (np imiona postaci, ogłoszenia headów).

fixes #154 

## Changelog
:cl:
fix: poprawne wyświetlanie się polskich znaków w książkach
/:cl:

<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
