### PR TITLE
Fix hygienebotów

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -78,6 +78,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("turret frame", /obj/machinery/porta_turret_construct, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("meatspike frame", /obj/structure/kitchenspike_frame, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("reflector frame", /obj/structure/reflector, 5, time = 25, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("hygienebot assembly", /obj/item/bot_assembly/hygienebot, 2, time = 50), \
 	null, \
 	new/datum/stack_recipe("pestle", /obj/item/pestle, 1, time = 50), \
 	new/datum/stack_recipe("grenade casing", /obj/item/grenade/chem_grenade), \


### PR DESCRIPTION
# O Pull Requeście
<!-- np zamyka jakiś issue, wtedy napisz "fixes #nn" gdzie nn to numer issue -->
Hygieneboty można już budować.

## Changelog
:cl:
fix: opcja craftingu hygienebotów po naciśnięciu metalu wyświetla się prawidłowo
/:cl:

<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
