### PR TITLE
Płytki "Borgi" dostępne w mechfabach

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -647,6 +647,12 @@
 	icon_state = "cyborg_upgrade3"
 	new_module = /obj/item/robot_module/clown
 
+/obj/item/borg/upgrade/transform/borgi
+	name = "borg module picker (Borgi)"
+	desc = "Allows you to to turn a cyborg into a borgi, woof."
+	icon_state = "cyborg_upgrade3"
+	new_module = /obj/item/robot_module/borgi
+
 /obj/item/borg/upgrade/circuit_app
 	name = "circuit manipulation apparatus"
 	desc = "An engineering cyborg upgrade allowing for manipulation of circuit boards."

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -695,6 +695,15 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_transform_borgi
+	name = "Cyborg Upgrade (Borgi Module)"
+	id = "borg_transform_borgi"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/transform/borgi
+	materials = list(/datum/material/iron = 15000, /datum/material/glass = 15000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_selfrepair
 	name = "Cyborg Upgrade (Self-repair)"
 	id = "borg_upgrade_selfrepair"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -367,6 +367,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
+/datum/techweb_node/cyborg_upg_borgi
+	id = "cyborg_upg_borgi"
+	display_name = "Cyborg Upgrades: Borgi"
+	description = "Woof woof bark!"
+	prereq_ids = list("adv_robotics")
+	design_ids = list("borg_transform_borgi")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
+	export_price = 1500
+
 /datum/techweb_node/ai
 	id = "ai"
 	display_name = "Artificial Intelligence"


### PR DESCRIPTION
# O Pull Requeście
Dodaje płytkę pozwalającą zmienić borga w pupila robotyki!
Dostępny po odkryciu odpowiedniego researchu.

## Changelog
:cl:
add: moduł cyborga "borgi" dostępny do wytworzenia w mechfabie
/:cl:

<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
