### PR TITLE
O dronach i kredkach

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -420,10 +420,13 @@
 		var/eaten = use_charges(user, 5, FALSE)
 		if(check_empty(user)) //Prevents divsion by zero
 			return
-		var/fraction = min(eaten / reagents.total_volume, 1)
-		reagents.reaction(M, INGEST, fraction * volume_multiplier)
-		reagents.trans_to(M, eaten, volume_multiplier, transfered_by = user)
-		// check_empty() is called during afterattack
+		if(!istype(M, /mob/living/simple_animal/drone))
+			var/fraction = min(eaten / reagents.total_volume, 1)
+			reagents.reaction(M, INGEST, fraction * volume_multiplier)
+			reagents.trans_to(M, eaten, volume_multiplier, transfered_by = user)
+		else
+			var/mob/living/simple_animal/drone/d = user
+			d.adjustHealth(-3)
 	else
 		..()
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -16,8 +16,8 @@
 #define SCOUTDRONE_HACKED "drone_scout_hacked"
 
 /mob/living/simple_animal/drone
-	name = "Drone"
-	desc = "A maintenance drone, an expendable robot built to perform station repairs."
+	name = "Dron"
+	desc = "Dron naprawczy, mały robot stworzony do napraw i konserwacji stacji kosmicznych."
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_maint_grey"
 	icon_living = "drone_maint_grey"
@@ -36,7 +36,7 @@
 	status_flags = (CANPUSH | CANSTUN | CANKNOCKDOWN)
 	gender = NEUTER
 	mob_biotypes = list(MOB_ROBOTIC)
-	speak_emote = list("chirps")
+	speak_emote = list("ćwierka")
 	speech_span = SPAN_ROBOT
 	bubble_icon = "machine"
 	initial_language_holder = /datum/language_holder/drone
@@ -58,9 +58,9 @@
 	var/colour = "grey"	//Stored drone color, so we can go back when unhacked.
 	var/list/drone_overlays[DRONE_TOTAL_LAYERS]
 	var/laws = \
-	"1. You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.\n"+\
-	"2. You may not harm any being, regardless of intent or circumstance.\n"+\
-	"3. Your goals are to actively build, maintain, repair, improve, and provide power to the best of your abilities within the facility that housed your activation." //for derelict drones so they don't go to station.
+	"1. <big>Nie możesz angażować się w sprawy innych istot, nawet gdyby konfliktowało z Prawem Drugim lub Trzecim, chyba, że inna istota też jest dronem.</big>\n"+\
+	"2. <big>Nie możesz skrzywdzić innej istoty niezależnie od okoliczności.</big>\n"+\
+	"3. <big>Buduj, naprawiaj, konserwuj i ulepszaj oraz zapewnij energię najlepiej jak potrafisz w placówce na której zostałeś aktywowany.</big>" //for derelict drones so they don't go to station.
 	var/heavy_emp_damage = 25 //Amount of damage sustained if hit by a heavy EMP pulse
 	var/alarms = list("Atmosphere" = list(), "Fire" = list(), "Power" = list())
 	var/obj/item/internal_storage //Drones can store one item, of any size/type in their body
@@ -70,14 +70,14 @@
 	var/visualAppearence = MAINTDRONE //What we appear as
 	var/hacked = FALSE //If we have laws to destroy the station
 	var/flavortext = \
-	"\n<big><span class='warning'>DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n"+\
-	"<span class='notify'>Drones are a ghost role that are allowed to fix the station and build things. Interfering with the round as a drone is against the rules.</span>\n"+\
-	"<span class='notify'>Actions that constitute interference include, but are not limited to:</span>\n"+\
-	"<span class='notify'>     - Interacting with round critical objects (IDs, weapons, contraband, powersinks, bombs, etc.)</span>\n"+\
-	"<span class='notify'>     - Interacting with living beings (communication, attacking, healing, etc.)</span>\n"+\
-	"<span class='notify'>     - Interacting with non-living beings (dragging bodies, looting bodies, etc.)</span>\n"+\
-	"<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n"+\
-	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>"
+	"\n<big><span class='warning'>NIE MIESZAJ SIĘ W SPRAWY INNYCH ISTOT ALBO OTRZYMASZ BANA NA DRONY</span></big>\n"+\
+	"<span class='notify'>Drony mogą budować, naprawiać i wydurniać się tak długo jak nie wpływa to poważnie na rundę.</span>\n"+\
+	"<big><span class='notify'>Przykłady 'poważnego wpływu' to:</span></big>\n"+\
+	"<span class='notify'>     - Jakiekolwiek interakcje z krytycznymi przedmiotami (karty ID, broń, kontrabanda, bomby, powersinki, etc.)</span>\n"+\
+	"<span class='notify'>     - Interakcje z żywymi niedronami (komunikowanie się, atakowanie, leczenie, ciągnięcie etc.)</span>\n"+\
+	"<span class='notify'>     - Interakcje z nieżywymi niedronami (ciągnięcie ciał, okradanie ciał etc.)</span>\n"+\
+	"<span class='warning'>W PRZYPADKU WĄTPLIWOŚCI ZAPYTAJ ADMINA</span>\n"+\
+	"<span class='warning'><u>Jeżeli nie posiadasz standardowego zestawu praw drona przestrzegaj go najlepiej jak umiesz.</u></span>"
 	mobsay_color = "#8AB48C"
 
 /mob/living/simple_animal/drone/Initialize()

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -7,8 +7,8 @@
 
 //DRONE SHELL
 /obj/item/drone_shell
-	name = "drone shell"
-	desc = "A shell of a maintenance drone, an expendable robot built to perform station repairs."
+	name = "Nieaktywny dron"
+	desc = "Nieaktywny dron naprawczy."
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_maint_hat"//yes reuse the _hat state.
 	layer = BELOW_MOB_LAYER

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -10,22 +10,22 @@
 
 //More types of drones
 /mob/living/simple_animal/drone/syndrone
-	name = "Syndrone"
-	desc = "A modified maintenance drone. This one brings with it the feeling of terror."
+	name = "Syndron"
+	desc = "Zmodyfikowany dron naprawczy Syndykatu. Wygląda jak zapowiedź kłopotów."
 	icon_state = "drone_synd"
 	icon_living = "drone_synd"
 	picked = TRUE //the appearence of syndrones is static, you don't get to change it.
-	health = 30
-	maxHealth = 120 //If you murder other drones and cannibalize them you can get much stronger
+	//health = 30
+	//maxHealth = 120 //If you murder other drones and cannibalize them you can get much stronger - it would be cool if it wasn't broken as hell
 	initial_language_holder = /datum/language_holder/drone/syndicate
 	faction = list(ROLE_SYNDICATE)
-	speak_emote = list("hisses")
+	speak_emote = list("syczy")
 	bubble_icon = "syndibot"
 	heavy_emp_damage = 10
 	laws = \
-	"1. Interfere.\n"+\
-	"2. Kill.\n"+\
-	"3. Destroy."
+	"1. Przeszkadzaj nie-syndronom.\n"+\
+	"2. Zabijaj nie-syndrony.\n"+\
+	"3. Niszcz nie-syndrony."
 	default_storage = /obj/item/storage/backpack/duffelbag/syndrone
 	default_hatmask = null
 	hacked = TRUE
@@ -38,7 +38,7 @@
 
 /mob/living/simple_animal/drone/syndrone/Login()
 	..()
-	to_chat(src, "<span class='notice'>You can kill and eat other drones to increase your health!</span>" )
+	to_chat(src, "<span class='notice'>Syndron online. Protokoły eksterminacji aktywne.</span>" )
 
 /mob/living/simple_animal/drone/syndrone/badass
 	name = "Badass Syndrone"
@@ -57,11 +57,11 @@
 
 /mob/living/simple_animal/drone/snowflake/Initialize()
 	. = ..()
-	desc += " This drone appears to have a complex holoprojector built on its 'head'."
+	desc += " Wygląda na to, że ten dron posiada na 'głowie' mały holoprojektor."
 
 /obj/item/drone_shell/syndrone
-	name = "syndrone shell"
-	desc = "A shell of a syndrone, a modified maintenance drone designed to infiltrate and annihilate."
+	name = "Nieaktywny syndron"
+	desc = "Nieaktywny zmodyfikowany dron naprawczy Syndykatu. Może lepiej, żeby się nie aktywował."
 	icon_state = "syndrone_item"
 	drone_type = /mob/living/simple_animal/drone/syndrone
 
@@ -70,8 +70,8 @@
 	drone_type = /mob/living/simple_animal/drone/syndrone/badass
 
 /obj/item/drone_shell/snowflake
-	name = "snowflake drone shell"
-	desc = "A shell of a snowflake drone, a maintenance drone with a built in holographic projector to display hats and masks."
+	name = "Nieaktywny holodron"
+	desc = "Nieaktywny dron naprawczy z wbudowanym holoprojektorem czapek."
 	drone_type = /mob/living/simple_animal/drone/snowflake
 
 /mob/living/simple_animal/drone/polymorphed


### PR DESCRIPTION
# O Pull Requeście
Mały PR naprawiający przeoczenie z syndronami, dodający tłumaczenia praw dronów i syndronów oraz ich flavour textów oraz sprawiający, że zagryzanie kredki leczy drona o 3HP.

## Changelog
:cl:
add: wszystkie typy dronów są teraz wyposażone w wewnętrzny procesor kredek, transformujący kredki zjedzone przez drona w drobne naprawy
tweak: poprawiono coś
fix: syndrony nie mogą już jednym prostym trickiem mieć 120HP
spellcheck: tłumaczenia praw i flavour textów dronów
/:cl:

<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
