### PR TITLE
Hotkey - zmiana wyposażenia mecha

### DIFF
--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -82,3 +82,16 @@
 	var/mob/living/carbon/C = user.mob
 	C.give()
 	return TRUE
+
+/datum/keybinding/carbon/mecha_change_eq
+	key = "F"
+	name = "mecha_change_eq"
+	full_name = "Change exosuit equipment"
+	description = "Change current exosuit equipment"
+
+/datum/keybinding/carbon/mecha_change_eq/down(client/user)
+	if(!ismecha(usr.loc)) return
+	var/obj/mecha/C = usr.loc
+	C.cycle_action.Activate()
+	return TRUE
+		


### PR DESCRIPTION
# O Pull Requeście
Dodaje hotkey służący do zmiany obecnie wybranego wyposażenia mecha. Domyślnie ustawiony na 'F' dla nowych graczy, osoby które już grały na Aquili będą musiały go ustawić ręcznie w ustawieniach.

## Changelog
:cl:
add: hotkey pozwalający zmienić obecne wyposażenie pilotowanego mecha
/:cl:

<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
