### PR TITLE
Spolszczenie Abductorów

### DIFF
--- a/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
@@ -45,7 +45,7 @@
 /datum/objective/abductee/calling/New()
 	var/mob/dead/D = pick(GLOB.dead_mob_list)
 	if(D)
-		explanation_text = "Wiesz, że [D] zginął. Przygotuj seans, by przywołać [D.p_them()] z zaświatów."
+		explanation_text = "Wiesz, że [D] zginął. Przygotuj seans, by przywołać duszę [D.p_them()] z zaświatów."
 
 /datum/objective/abductee/forbiddennumber
 

--- a/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
@@ -7,28 +7,28 @@
 	explanation_text = pick(world.file2list("strings/abductee_objectives.txt"))
 
 /datum/objective/abductee/steal
-	explanation_text = "Steal all"
+	explanation_text = "Ukradnij wszystkie"
 
 /datum/objective/abductee/steal/New()
-	var/target = pick(list("pets","lights","monkeys","fruits","shoes","bars of soap", "weapons", "computers", "organs"))
+	var/target = pick(list("zwierzęta","światła","małpy","owoce","buty","kostki mydła", "bronie", "komputery", "organy"))
 	explanation_text+=" [target]."
 
 /datum/objective/abductee/paint
-	explanation_text = "The station is hideous. You must color it all"
+	explanation_text = "Stacja jest brzydka. Musisz ją pokolorować"
 
 /datum/objective/abductee/paint/New()
-	var/color = pick(list("red", "blue", "green", "yellow", "orange", "purple", "black", "in rainbows", "in blood"))
+	var/color = pick(list("na czerwono", "na niebiesko", "na zielono", "na zółto", "na pomarańczowo", "na fioletowo", "na czarno", "na tęczowo", "we krwi"))
 	explanation_text+= " [color]!"
 
 /datum/objective/abductee/speech
-	explanation_text = "Your brain is broken... you can only communicate in"
+	explanation_text = "Twój mózg jest zepsuty... możesz komunikować się jedynie za pomocą"
 
 /datum/objective/abductee/speech/New()
-	var/style = pick(list("pantomime", "rhyme", "haiku", "extended metaphors", "riddles", "extremely literal terms", "sound effects", "military jargon", "three word sentences"))
+	var/style = pick(list("pantomimy", "rymowanek", "haiku", "wydłużonych metafor", "łamigłówek", "ekstremalnych terminów dosłownych", "efektów dźwiękowych", "żargonu wojskowego", "zdań trzywyrazowych"))
 	explanation_text+= " [style]."
 
 /datum/objective/abductee/capture
-	explanation_text = "Capture"
+	explanation_text = "Schwytaj"
 
 /datum/objective/abductee/capture/New()
 	var/list/jobs = SSjob.occupations.Copy()
@@ -38,17 +38,17 @@
 			jobs -= J
 	if(jobs.len > 0)
 		var/datum/job/target = pick(jobs)
-		explanation_text += " a [target.title]."
+		explanation_text += " jakiegoś [target.title]."
 	else
-		explanation_text += " someone."
+		explanation_text += " kogoś."
 
 /datum/objective/abductee/calling/New()
 	var/mob/dead/D = pick(GLOB.dead_mob_list)
 	if(D)
-		explanation_text = "You know that [D] has perished. Hold a seance to call [D.p_them()] from the spirit realm."
+		explanation_text = "Wiesz, że [D] zginął. Przygotuj seans, by przywołać [D.p_them()] z zaświatów."
 
 /datum/objective/abductee/forbiddennumber
 
 /datum/objective/abductee/forbiddennumber/New()
 	var/number = rand(2,10)
-	explanation_text = "Ignore anything in a set of [number], they don't exist."
+	explanation_text = "Ingoruj wszystko co występuje w ilości [number], to nie istnieje."

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -180,7 +180,7 @@
 
 /datum/antagonist/abductee/greet()
 	to_chat(owner, "<span class='warning'><b>Twój umysł pęka w szwach!</b></span>")
-	to_chat(owner, "<big><span class='warning'><b>YNie pamiętasz, jak się tu dostałeś. . .</b></span></big>")
+	to_chat(owner, "<big><span class='warning'><b>Nie pamiętasz, jak się tu dostałeś. . .</b></span></big>")
 	owner.announce_objectives()
 
 /datum/antagonist/abductee/proc/give_objective()
@@ -213,7 +213,7 @@
 	target_amount = 6
 
 /datum/objective/experiment/New()
-	explanation_text = "Przeprowadźcie eksperymenty na [target_amount] ludziach."
+	explanation_text = "Przeprowadź eksperymenty na [target_amount] osobach."
 
 /datum/objective/experiment/check_completion()
 	for(var/obj/machinery/abductor/experiment/E in GLOB.machines)

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -2,7 +2,7 @@
 
 /datum/antagonist/abductor
 	name = "Abductor"
-	roundend_category = "abductors"
+	roundend_category = "porywacze"
 	antagpanel_category = "Abductor"
 	job_rank = ROLE_ABDUCTOR
 	show_in_antagpanel = FALSE //should only show subtypes

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -27,7 +27,7 @@
 	sub_role = "Scientist"
 	outfit = /datum/outfit/abductor/scientist
 	landmark_type = /obj/effect/landmark/abductor/scientist
-	greet_text = "Używaj swojej konsoli eksperymentacyjnej by monitorować swojego agenta, oraz sprzętu chirurgicznego do eksperymentów na porwanych ludziach."
+	greet_text = "Używaj swojej konsoli eksperymentacyjnej, by monitorować swojego agenta oraz sprzętu chirurgicznego do eksperymentów na porwanych ludziach."
 	show_in_antagpanel = TRUE
 
 /datum/antagonist/abductor/scientist/onemanteam
@@ -64,8 +64,8 @@
 /datum/antagonist/abductor/greet()
 	to_chat(owner.current, "<span class='notice'>Zostałeś wybrany jako [owner.special_role]!</span>")
 	to_chat(owner.current, "<span class='notice'>Z pomocą twojego kolegi, porywaj i eksperymentuj na członkach załogi!</span>")
-	to_chat(owner.current, "<span class='notice'>Jest was dwóch! Jeden z was może minotrować kamery, gdy drugi infiltruje stację.</span>")
-	to_chat(owner.current, "<span class='notice'>Wybierzcie dorbe przebranie oraz swoje cele z głową! Załoga spróbuje was zabić przy każdej okazji.</span>")
+	to_chat(owner.current, "<span class='notice'>Jest was dwóch! Jeden z was może monitorować kamery, gdy drugi infiltruje stację.</span>")
+	to_chat(owner.current, "<span class='notice'>Wybierzcie dobre przebranie oraz swoje cele z głową! Załoga spróbuje was zabić przy każdej okazji.</span>")
 	to_chat(owner.current, "<span class='notice'>[greet_text]</span>")
 	owner.announce_objectives()
 

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -15,23 +15,23 @@
 
 
 /datum/antagonist/abductor/agent
-	name = "Abductor Agent"
+	name = "Agent Porywaczy"
 	sub_role = "Agent"
 	outfit = /datum/outfit/abductor/agent
 	landmark_type = /obj/effect/landmark/abductor/agent
-	greet_text = "Use your stealth technology and equipment to incapacitate humans for your scientist to retrieve."
+	greet_text = "Używaj swojej technologii maskowania oraz sprzętu, by obezwładniać ludzi dla swojego naukowca, który sprowadzi ich na pokład w celu eksperymentów."
 	show_in_antagpanel = TRUE
 
 /datum/antagonist/abductor/scientist
-	name = "Abductor Scientist"
+	name = "Naukowiec Porywaczy"
 	sub_role = "Scientist"
 	outfit = /datum/outfit/abductor/scientist
 	landmark_type = /obj/effect/landmark/abductor/scientist
-	greet_text = "Use your experimental console and surgical equipment to monitor your agent and experiment upon abducted humans."
+	greet_text = "Używaj swojej konsoli eksperymentacyjnej by monitorować swojego agenta, oraz sprzętu chirurgicznego do eksperymentów na porwanych ludziach."
 	show_in_antagpanel = TRUE
 
 /datum/antagonist/abductor/scientist/onemanteam
-	name = "Abductor Solo"
+	name = "Samotny Porywacz"
 	outfit = /datum/outfit/abductor/scientist/onemanteam
 
 /datum/antagonist/abductor/create_team(datum/team/abductor_team/new_team)
@@ -56,16 +56,16 @@
 
 /datum/antagonist/abductor/on_removal()
 	if(owner.current)
-		to_chat(owner.current,"<span class='userdanger'>You are no longer the [owner.special_role]!</span>")
+		to_chat(owner.current,"<span class='userdanger'>Nie jesteś już! [owner.special_role]!</span>")
 	owner.special_role = null
 	REMOVE_TRAIT(owner, TRAIT_ABDUCTOR_TRAINING, ABDUCTOR_ANTAGONIST)
 	return ..()
 
 /datum/antagonist/abductor/greet()
-	to_chat(owner.current, "<span class='notice'>You are the [owner.special_role]!</span>")
-	to_chat(owner.current, "<span class='notice'>With the help of your teammate, kidnap and experiment on station crew members!</span>")
-	to_chat(owner.current, "<span class='notice'>There are two of you! One can monitor cameras while the other infiltrates the station.</span>")
-	to_chat(owner.current, "<span class='notice'>Choose a worthy disguise and plan your targets carefully! Humans will kill you on sight.</span>")
+	to_chat(owner.current, "<span class='notice'>Zostałeś wybrany jako [owner.special_role]!</span>")
+	to_chat(owner.current, "<span class='notice'>Z pomocą twojego kolegi, porywaj i eksperymentuj na członkach załogi!</span>")
+	to_chat(owner.current, "<span class='notice'>Jest was dwóch! Jeden z was może minotrować kamery, gdy drugi infiltruje stację.</span>")
+	to_chat(owner.current, "<span class='notice'>Wybierzcie dorbe przebranie oraz swoje cele z głową! Załoga spróbuje was zabić przy każdej okazji.</span>")
 	to_chat(owner.current, "<span class='notice'>[greet_text]</span>")
 	owner.announce_objectives()
 
@@ -129,7 +129,7 @@
 			H.equipOutfit(/datum/outfit/abductor/scientist)
 
 /datum/team/abductor_team
-	member_name = "abductor"
+	member_name = "porywacz"
 	var/team_number
 	var/list/datum/mind/abductees = list()
 	var/static/team_count = 1
@@ -137,7 +137,7 @@
 /datum/team/abductor_team/New()
 	..()
 	team_number = team_count++
-	name = "Mothership [pick(GLOB.possible_changeling_IDs)]" //TODO Ensure unique and actual alieny names
+	name = "Statek-Matka [pick(GLOB.possible_changeling_IDs)]" //TODO Ensure unique and actual alieny names
 	add_objective(new/datum/objective/experiment)
 
 /datum/team/abductor_team/is_solo()
@@ -158,11 +158,11 @@
 		if(!O.check_completion())
 			won = FALSE
 	if(won)
-		result += "<span class='greentext big'>[name] team fulfilled its mission!</span>"
+		result += "<span class='greentext big'>Drużyna [name] wypełniła swoją misję!</span>"
 	else
-		result += "<span class='redtext big'>[name] team failed its mission.</span>"
+		result += "<span class='redtext big'>Drużyna [name] spaliła swoją misję!</span>"
 
-	result += "<span class='header'>The abductors of [name] were:</span>"
+	result += "<span class='header'>Porywaczami drużyny [name] byli:</span>"
 	for(var/datum/mind/abductor_mind in members)
 		result += printplayer(abductor_mind)
 	result += printobjectives(objectives)
@@ -171,7 +171,7 @@
 
 /datum/antagonist/abductee
 	name = "Abductee"
-	roundend_category = "abductees"
+	roundend_category = "porwani"
 	antagpanel_category = "Abductee"
 
 /datum/antagonist/abductee/on_gain()
@@ -179,8 +179,8 @@
 	. = ..()
 
 /datum/antagonist/abductee/greet()
-	to_chat(owner, "<span class='warning'><b>Your mind snaps!</b></span>")
-	to_chat(owner, "<big><span class='warning'><b>You can't remember how you got here...</b></span></big>")
+	to_chat(owner, "<span class='warning'><b>Twój umysł pęka w szwach!</b></span>")
+	to_chat(owner, "<big><span class='warning'><b>YNie pamiętasz, jak się tu dostałeś. . .</b></span></big>")
 	owner.announce_objectives()
 
 /datum/antagonist/abductee/proc/give_objective()
@@ -213,7 +213,7 @@
 	target_amount = 6
 
 /datum/objective/experiment/New()
-	explanation_text = "Experiment on [target_amount] humans."
+	explanation_text = "Przeprowadźcie eksperymenty na [target_amount] ludziach."
 
 /datum/objective/experiment/check_completion()
 	for(var/obj/machinery/abductor/experiment/E in GLOB.machines)

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -137,7 +137,7 @@
 /datum/team/abductor_team/New()
 	..()
 	team_number = team_count++
-	name = "Statek-Matka [pick(GLOB.possible_changeling_IDs)]" //TODO Ensure unique and actual alieny names
+	name = "[pick(GLOB.possible_changeling_IDs)]" //TODO Ensure unique and actual alieny names
 	add_objective(new/datum/objective/experiment)
 
 /datum/team/abductor_team/is_solo()

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -8,7 +8,7 @@
 //AGENT VEST
 /obj/item/clothing/suit/armor/abductor/vest
 	name = "kamizelka agenta"
-	desc = "Kamizelka z wbudowaną zaawansowaną technologią maskowania. Posiada dwa tryby - maskowanie oraz walka."
+	desc = "Kamizelka ze wbudowaną zaawansowaną technologią maskowania. Posiada dwa tryby: maskowanie oraz walka."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "vest_stealth"
 	item_state = "armor"
@@ -252,7 +252,7 @@
 
 /obj/item/abductor/silencer
 	name = "uciszacz porywaczy"
-	desc = "Kompaktowe urządzenie pozwalające wyłączyć sprzęt komunikacyjny."
+	desc = "Kompaktowe urządzenie pozwalające wyłączać sprzęt komunikacyjny."
 	icon_state = "silencer"
 	item_state = "gizmo"
 
@@ -367,7 +367,7 @@
 		if(QDELETED(L) || L.stat == DEAD)
 			return
 
-		to_chat(L, "<span class='italics'>Słyszysz głos w swojej głosie mówiący: </span><span class='abductor'>[message]</span>")
+		to_chat(L, "<span class='italics'>Słyszysz głos w swojej głowie, mówiący: </span><span class='abductor'>[message]</span>")
 		to_chat(user, "<span class='notice'>Wysyłasz wiadmość do swojego celu.</span>")
 		log_directed_talk(user, L, message, LOG_SAY, "abductor whisper")
 
@@ -589,7 +589,7 @@ Gratulacje! Jesteś teraz wyszkolony do inwazyjnych badań ksenobiologicznych!"}
 
 /obj/item/restraints/handcuffs/energy
 	name = "twarde pole energetyczne"
-	desc = "twarde pole energetyczne służące jak kajdanki."
+	desc = "twarde pole energetyczne działające jak kajdanki."
 	icon_state = "cuff" // Needs sprite
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
@@ -796,7 +796,7 @@ Gratulacje! Jesteś teraz wyszkolony do inwazyjnych badań ksenobiologicznych!"}
 	. = ..()
 	if(iscarbon(AM))
 		START_PROCESSING(SSobj, src)
-		to_chat(AM, "<span class='danger'>You feel a series of tiny pricks!</span>")
+		to_chat(AM, "<span class='danger'>Czujesz serię małych ukłuć!/span>")
 
 /obj/structure/table/optable/abductor/process()
 	. = PROCESS_KILL
@@ -812,7 +812,7 @@ Gratulacje! Jesteś teraz wyszkolony do inwazyjnych badań ksenobiologicznych!"}
 
 /obj/structure/closet/abductor
 	name = "szafka obcych"
-	desc = "Posiada sekrety wszechświata."
+	desc = "Zawiera sekrety wszechświata."
 	icon_state = "abductor"
 	icon_door = "abductor"
 	can_weld_shut = FALSE

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -712,7 +712,7 @@ Gratulacje! Jesteś teraz wyszkolony do inwazyjnych badań ksenobiologicznych!"}
 
 /obj/item/clothing/head/helmet/abductor
 	name = "hełm agenta"
-	desc = "Porywaj ze stylem - spiczastym stylem. Zapobiega śledzenia przez kamery."
+	desc = "Porywaj ze stylem - spiczastym stylem. Zapobiega śledzeniu przez kamery."
 	icon_state = "alienhelmet"
 	item_state = "alienhelmet"
 	blockTracking = TRUE

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -728,7 +728,7 @@ Gratulacje! Jesteś teraz wyszkolony do inwazyjnych badań ksenobiologicznych!"}
 	icon_state = "bed"
 
 /obj/structure/table_frame/abductor
-	name = "rama stołu obcych
+	name = "rama stołu obcych"
 	desc = "Wytrzymała rama stołu zrobiona ze stopu obcych."
 	icon_state = "alien_frame"
 	framestack = /obj/item/stack/sheet/mineral/abductor

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -375,7 +375,7 @@
 /obj/item/firing_pin/abductor
 	name = "dziwna iglica"
 	icon_state = "firing_pin_ayy"
-	desc = "Ta iglica jes śliska i ciepła; This firing pin is slimy and warm; możesz przysiąc, że czujesz, że ciągle próbuje cię badać psychicznie."
+	desc = "Ta iglica jes śliska i ciepła; możesz przysiąc, że czujesz, że ciągle próbuje cię badać psychicznie."
 	fail_message = "<span class='abductor'>Błąd wystrzału, proszę skontaktować się z producentem.</span>"
 
 /obj/item/firing_pin/abductor/pin_auth(mob/living/user)

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -448,7 +448,7 @@ Gratulacje! Jesteś teraz wyszkolony do inwazyjnych badań ksenobiologicznych!"}
 		if(BATON_PROBE)
 			txt = "sondowania"
 
-	to_chat(usr, "<span class='notice'>Zmieniasz pałkę na tryb [txt] mode.</span>")
+	to_chat(usr, "<span class='notice'>Zmieniasz pałkę na tryb [txt].</span>")
 	update_icon()
 
 /obj/item/abductor/baton/update_icon()

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -7,8 +7,8 @@
 
 //AGENT VEST
 /obj/item/clothing/suit/armor/abductor/vest
-	name = "agent vest"
-	desc = "A vest outfitted with advanced stealth technology. It has two modes - combat and stealth."
+	name = "kamizelka agenta"
+	desc = "Kamizelka z wbudowaną zaawansowaną technologią maskowania. Posiada dwa tryby - maskowanie oraz walka."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "vest_stealth"
 	item_state = "armor"
@@ -40,7 +40,7 @@
 	else
 		ADD_TRAIT(src, TRAIT_NODROP, ABDUCTOR_VEST_TRAIT)
 	if(ismob(loc))
-		to_chat(loc, "<span class='notice'>Your vest is now [HAS_TRAIT_FROM(src, TRAIT_NODROP, ABDUCTOR_VEST_TRAIT) ? "locked" : "unlocked"].</span>")
+		to_chat(loc, "<span class='notice'>Twoja kamizelka jest teraz [HAS_TRAIT_FROM(src, TRAIT_NODROP, ABDUCTOR_VEST_TRAIT) ? "zablokowana" : "odblokowana"].</span>")
 
 /obj/item/clothing/suit/armor/abductor/vest/proc/flip_mode()
 	switch(mode)
@@ -111,7 +111,7 @@
 /obj/item/clothing/suit/armor/abductor/vest/proc/Adrenaline()
 	if(ishuman(loc))
 		if(combat_cooldown != initial(combat_cooldown))
-			to_chat(loc, "<span class='warning'>Combat injection is still recharging.</span>")
+			to_chat(loc, "<span class='warning'>Zastrzyk bojowy wciąż się ładuje.</span>")
 			return
 		var/mob/living/carbon/human/M = loc
 		M.adjustStaminaLoss(-75)
@@ -147,7 +147,7 @@
 		return TRUE
 	if (istype(user) && user.mind && HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_TRAINING))
 		return TRUE
-	to_chat(user, "<span class='warning'>You can't figure how this works!</span>")
+	to_chat(user, "<span class='warning'>Nie masz pojęcia jak tego użyć!</span>")
 	return FALSE
 
 /obj/item/abductor/proc/ScientistCheck(mob/user)
@@ -155,17 +155,17 @@
 	var/sci_training = HAS_TRAIT(user, TRAIT_ABDUCTOR_SCIENTIST_TRAINING) || (user.mind && HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
 
 	if(training && !sci_training)
-		to_chat(user, "<span class='warning'>You're not trained to use this!</span>")
+		to_chat(user, "<span class='warning'>Nie posiadasz umiejętności by tego użyć!</span>")
 		. = FALSE
 	else if(!training && !sci_training)
-		to_chat(user, "<span class='warning'>You can't figure how this works!</span>")
+		to_chat(user, "<span class='warning'>Nie masz pojęcia jak tego użyć!</span>")
 		. = FALSE
 	else
 		. = TRUE
 
 /obj/item/abductor/gizmo
-	name = "science tool"
-	desc = "A dual-mode tool for retrieving specimens and scanning appearances. Scanning can be done through cameras."
+	name = "narzędzie naukowe"
+	desc = "Narzędzie o podwójnym trybie do odzyskiwania osobników oraz skanowania wyglądu. Skan może zostać wykonany przez kamery."
 	icon_state = "gizmo_scan"
 	item_state = "silencer"
 	var/mode = GIZMO_SCAN
@@ -176,7 +176,7 @@
 	if(!ScientistCheck(user))
 		return
 	if(!console)
-		to_chat(user, "<span class='warning'>The device is not linked to console!</span>")
+		to_chat(user, "<span class='warning'>Urządzenie nie jest połączone z konsolą!</span>")
 		return
 
 	if(mode == GIZMO_SCAN)
@@ -185,13 +185,13 @@
 	else
 		mode = GIZMO_SCAN
 		icon_state = "gizmo_scan"
-	to_chat(user, "<span class='notice'>You switch the device to [mode==GIZMO_SCAN? "SCAN": "MARK"] MODE</span>")
+	to_chat(user, "<span class='notice'>Przestawiasz narzędzie na tryb [mode==GIZMO_SCAN? "SKAN": "ZAZNACZ"]</span>")
 
 /obj/item/abductor/gizmo/attack(mob/living/M, mob/user)
 	if(!ScientistCheck(user))
 		return
 	if(!console)
-		to_chat(user, "<span class='warning'>The device is not linked to console!</span>")
+		to_chat(user, "<span class='warning'>Urządzenie nie jest połączone z konsolą!</span>")
 		return
 
 	switch(mode)
@@ -208,7 +208,7 @@
 	if(!ScientistCheck(user))
 		return
 	if(!console)
-		to_chat(user, "<span class='warning'>The device is not linked to console!</span>")
+		to_chat(user, "<span class='warning'>Urządzenie nie jest połączone z konsolą!</span>")
 		return
 
 	switch(mode)
@@ -220,16 +220,16 @@
 /obj/item/abductor/gizmo/proc/scan(atom/target, mob/living/user)
 	if(ishuman(target))
 		console.AddSnapshot(target)
-		to_chat(user, "<span class='notice'>You scan [target] and add [target.p_them()] to the database.</span>")
+		to_chat(user, "<span class='notice'>Skanujesz [target], dodając ich do bazy danych.</span>")
 
 /obj/item/abductor/gizmo/proc/mark(atom/target, mob/living/user)
 	if(marked == target)
-		to_chat(user, "<span class='warning'>This specimen is already marked!</span>")
+		to_chat(user, "<span class='warning'>Ten osobnik został już oznaczony!</span>")
 		return
 	if(ishuman(target))
 		if(isabductor(target))
 			marked = target
-			to_chat(user, "<span class='notice'>You mark [target] for future retrieval.</span>")
+			to_chat(user, "<span class='notice'>Zaznaczasz [target] na późniejsze odzyskanie.</span>")
 		else
 			prepare(target,user)
 	else
@@ -237,12 +237,12 @@
 
 /obj/item/abductor/gizmo/proc/prepare(atom/target, mob/living/user)
 	if(get_dist(target,user)>1)
-		to_chat(user, "<span class='warning'>You need to be next to the specimen to prepare it for transport!</span>")
+		to_chat(user, "<span class='warning'>Musisz stać obok osobnika by przygotować go do transportu!</span>")
 		return
-	to_chat(user, "<span class='notice'>You begin preparing [target] for transport...</span>")
+	to_chat(user, "<span class='notice'>Zaczynasz przygotowywać [target] do transportu...</span>")
 	if(do_after(user, 100, target = target))
 		marked = target
-		to_chat(user, "<span class='notice'>You finish preparing [target] for transport.</span>")
+		to_chat(user, "<span class='notice'>Zakańczasz przygotowywać [target] do transportu.</span>")
 
 /obj/item/abductor/gizmo/Destroy()
 	if(console)
@@ -251,8 +251,8 @@
 
 
 /obj/item/abductor/silencer
-	name = "abductor silencer"
-	desc = "A compact device used to shut down communications equipment."
+	name = "uciszacz porywaczy"
+	desc = "Kompaktowe urządzenie pozwalające wyłączyć sprzęt komunikacyjny."
 	icon_state = "silencer"
 	item_state = "gizmo"
 
@@ -279,7 +279,7 @@
 	for(M in view(2,targloc))
 		if(M == user)
 			continue
-		to_chat(user, "<span class='notice'>You silence [M]'s radio devices.</span>")
+		to_chat(user, "<span class='notice'>Wyłączasz urządzenia komunikacyjne dla [M]</span>")
 		radio_off_mob(M)
 
 /obj/item/abductor/silencer/proc/radio_off_mob(mob/living/carbon/human/M)
@@ -293,9 +293,8 @@
 				r.broadcasting = 0 //goddamned headset hacks
 
 /obj/item/abductor/mind_device
-	name = "mental interface device"
-	desc = "A dual-mode tool for directly communicating with sentient brains. It can be used to send a direct message to a target, \
-			or to send a command to a test subject with a charged gland."
+	name = "interfejs mentalny"
+	desc = "Narzędzie o podwójnym trybie służące do komunikowania się ze świadomym mózgiem. Może zostać użyte do wysłania bezpośredniej wiadomości do celu lub, by wysłać polecenie do obiektu testowego z naładowanym glandem."
 	icon_state = "mind_device_message"
 	item_state = "silencer"
 	var/mode = MIND_DEVICE_MESSAGE
@@ -310,7 +309,7 @@
 	else
 		mode = MIND_DEVICE_MESSAGE
 		icon_state = "mind_device_message"
-	to_chat(user, "<span class='notice'>You switch the device to [mode==MIND_DEVICE_MESSAGE? "TRANSMISSION": "COMMAND"] MODE</span>")
+	to_chat(user, "<span class='notice'>Zmieniasz tryb urządzenia na [mode==MIND_DEVICE_MESSAGE? "TRANSMISJA": "POLECENIE"]</span>")
 
 /obj/item/abductor/mind_device/afterattack(atom/target, mob/living/user, flag, params)
 	. = ..()
@@ -328,17 +327,17 @@
 		var/mob/living/carbon/C = target
 		var/obj/item/organ/heart/gland/G = C.getorganslot("heart")
 		if(!istype(G))
-			to_chat(user, "<span class='warning'>Your target does not have an experimental gland!</span>")
+			to_chat(user, "<span class='warning'>Wybrany cel nie posiada glanda!</span>")
 			return
 		if(!G.mind_control_uses)
-			to_chat(user, "<span class='warning'>Your target's gland is spent!</span>")
+			to_chat(user, "<span class='warning'>Wybrany cel ma już zużytego glanda!</span>")
 			return
 		if(G.active_mind_control)
-			to_chat(user, "<span class='warning'>Your target is already under a mind-controlling influence!</span>")
+			to_chat(user, "<span class='warning'>Wybrany cel jest już pod wpływem kontroli umysłu!</span>")
 			return
 
-		var/command = stripped_input(user, "Enter the command for your target to follow.\
-											Uses Left: [G.mind_control_uses], Duration: [DisplayTimeText(G.mind_control_duration)]","Enter command")
+		var/command = stripped_input(user, "Podaj polecenie dla tego celu.\
+											Pozostało użyć: [G.mind_control_uses], Czas trwania: [DisplayTimeText(G.mind_control_duration)]","Enter command")
 
 		if(!command)
 			return
@@ -350,43 +349,41 @@
 			return
 
 		if(istype(C.get_item_by_slot(SLOT_HEAD), /obj/item/clothing/head/foilhat))
-			to_chat(user, "<span class='warning'>Your target seems to have some sort of protective headgear on, blocking the message from being sent!</span>")
+			to_chat(user, "<span class='warning'>Twój cel posiada nieznany obiekt ochronny na głowie, blokuje on twoją wiadomość!</span>")
 			return
 
 		G.mind_control(command, user)
-		to_chat(user, "<span class='notice'>You send the command to your target.</span>")
+		to_chat(user, "<span class='notice'>Przesyłasz polecenie do swojego celu.</span>")
 
 /obj/item/abductor/mind_device/proc/mind_message(atom/target, mob/living/user)
 	if(isliving(target))
 		var/mob/living/L = target
 		if(L.stat == DEAD)
-			to_chat(user, "<span class='warning'>Your target is dead!</span>")
+			to_chat(user, "<span class='warning'>Twój cel jest martwy!</span>")
 			return
-		var/message = stripped_input(user, "Write a message to send to your target's brain.","Enter message")
+		var/message = stripped_input(user, "Podaj wiadomość, którą chcesz wysłać do swojego celu.","Podaj Wiadomość")
 		if(!message)
 			return
 		if(QDELETED(L) || L.stat == DEAD)
 			return
 
-		to_chat(L, "<span class='italics'>You hear a voice in your head saying: </span><span class='abductor'>[message]</span>")
-		to_chat(user, "<span class='notice'>You send the message to your target.</span>")
+		to_chat(L, "<span class='italics'>Słyszysz głos w swojej głosie mówiący: </span><span class='abductor'>[message]</span>")
+		to_chat(user, "<span class='notice'>Wysyłasz wiadmość do swojego celu.</span>")
 		log_directed_talk(user, L, message, LOG_SAY, "abductor whisper")
 
 
 /obj/item/firing_pin/abductor
-	name = "alien firing pin"
+	name = "dziwna iglica"
 	icon_state = "firing_pin_ayy"
-	desc = "This firing pin is slimy and warm; you can swear you feel it \
-		constantly trying to mentally probe you."
-	fail_message = "<span class='abductor'>\
-		Firing error, please contact Command.</span>"
+	desc = "Ta iglica jes śliska i ciepła; This firing pin is slimy and warm; możesz przysiąc, że czujesz, że ciągle próbuje cię badać psychicznie."
+	fail_message = "<span class='abductor'>Błąd wystrzału, proszę skontaktować się z producentem.</span>"
 
 /obj/item/firing_pin/abductor/pin_auth(mob/living/user)
 	. = isabductor(user)
 
 /obj/item/gun/energy/alien
-	name = "alien pistol"
-	desc = "A complicated gun that fires bursts of high-intensity radiation."
+	name = "pistolet obcych"
+	desc = "Skomplikowany pistolet strzelający seriami promieniowania o dużej intensywności."
 	ammo_type = list(/obj/item/ammo_casing/energy/declone)
 	pin = /obj/item/firing_pin/abductor
 	icon_state = "alienpistol"
@@ -394,26 +391,26 @@
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
 /obj/item/paper/guides/antag/abductor
-	name = "Dissection Guide"
+	name = "Dysekcja - Poradnik"
 	icon_state = "alienpaper_words"
-	info = {"<b>Dissection for Dummies</b><br>
+	info = {"<b>Dysekcja dla Początkujących</b><br>
 
 <br>
- 1.Acquire fresh specimen.<br>
- 2.Put the specimen on operating table.<br>
- 3.Apply surgical drapes, preparing for experimental dissection.<br>
- 4.Apply scalpel to specimen's torso.<br>
- 5.Clamp bleeders on specimen's torso with a hemostat.<br>
- 6.Retract skin of specimen's torso with a retractor.<br>
- 7.Apply scalpel again to specimen's torso.<br>
- 8.Search through the specimen's torso with your hands to remove any superfluous organs.<br>
- 9.Insert replacement gland (Retrieve one from gland storage).<br>
- 10.Consider dressing the specimen back to not disturb the habitat. <br>
- 11.Put the specimen in the experiment machinery.<br>
- 12.Choose one of the machine options. The target will be analyzed and teleported to the selected drop-off point.<br>
- 13.You will receive one supply credit, and the subject will be counted towards your quota.<br>
+ 1.Zdobądź świeżego osobnika.<br>
+ 2.Połóż osobnika na stole operacyjnym.<br>
+ 3.Użyj surgical drapes na klatce piersiowej, i przygotuj do experimental dissection.<br>
+ 4.Użyj scalpel na klatce piersiowej osobnika.<br>
+ 5.Zatrzymaj krwawienie za pomocą hemostatu.<br>
+ 6.Cofnij skórę osobnika za pomocą retractora.<br>
+ 7.Użyj ponownie skalpela.<br>
+ 8.Poszukaj zbędnych organów w klatce piersiowej osobnika za pomocą rąk.<br>
+ 9.Wsadź zastępczy gland (Odbierz jeden z jednostki magazynowej glandów).<br>
+ 10.Ubierz osobnika by nie wzbudzać podejżeń. <br>
+ 11.Wsadź osobnika do maszyny eksperymentalnej.<br>
+ 12.Wybierz jedną z opcji maszyny. Cel zostanie przeanalizowany i teleportowany do wybranego punktu docelowego.<br>
+ 13.Otrzymasz jeden kredyt na sprzęt, a osobnik zostanie zaliczony do waszego zadania<br>
 <br>
-Congratulations! You are now trained for invasive xenobiology research!"}
+Gratulacje! Jesteś teraz wyszkolony do inwazyjnych badań ksenobiologicznych!"}
 
 /obj/item/paper/guides/antag/abductor/update_icon()
 	return
@@ -428,8 +425,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 #define BATON_MODES 4
 
 /obj/item/abductor/baton
-	name = "advanced baton"
-	desc = "A quad-mode baton used for incapacitation and restraining of specimens."
+	name = "zaawansowana pałka"
+	desc = "Czterotrybowa pałka służąca do obezwładnienia okazów badawczych."
 	var/mode = BATON_STUN
 	icon_state = "wonderprodStun"
 	item_state = "wonderprod"
@@ -443,15 +440,15 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	var/txt
 	switch(mode)
 		if(BATON_STUN)
-			txt = "stunning"
+			txt = "ogłuszania"
 		if(BATON_SLEEP)
-			txt = "sleep inducement"
+			txt = "usypiania"
 		if(BATON_CUFF)
-			txt = "restraining"
+			txt = "zakuwania"
 		if(BATON_PROBE)
-			txt = "probing"
+			txt = "sondowania"
 
-	to_chat(usr, "<span class='notice'>You switch the baton to [txt] mode.</span>")
+	to_chat(usr, "<span class='notice'>Zmieniasz pałkę na tryb [txt] mode.</span>")
 	update_icon()
 
 /obj/item/abductor/baton/update_icon()
@@ -525,26 +522,26 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 /obj/item/abductor/baton/proc/SleepAttack(mob/living/L,mob/living/user)
 	if(L.incapacitated(TRUE, TRUE))
 		if(istype(L.get_item_by_slot(SLOT_HEAD), /obj/item/clothing/head/foilhat))
-			to_chat(user, "<span class='warning'>The specimen's protective headgear is interfering with the sleep inducement!</span>")
+			to_chat(user, "<span class='warning'>Nakrycie głowy osobnika częściowo uniemożliwia pozbawiania go przytomności!</span>")
 			L.visible_message("<span class='danger'>[user] tried to induced sleep in [L] with [src], but [L.p_their()] headgear protected [L.p_them()]!</span>", \
-								"<span class='userdanger'>You feel a strange wave of heavy drowsiness wash over you, but your headgear deflects most of it!</span>")
+								"<span class='userdanger'>Czujesz dziwną falę ciężkiej senności, ale twoje nakrycie głowy odbija jej większość!</span>")
 			L.drowsyness += 2
 			return
 		L.visible_message("<span class='danger'>[user] has induced sleep in [L] with [src]!</span>", \
-							"<span class='userdanger'>You suddenly feel very drowsy!</span>")
+							"<span class='userdanger'>Nagle czujesz się bardzo senny!</span>")
 		playsound(src, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
 		L.Sleeping(1200)
 		log_combat(user, L, "put to sleep")
 	else
 		if(istype(L.get_item_by_slot(SLOT_HEAD), /obj/item/clothing/head/foilhat))
-			to_chat(user, "<span class='warning'>The specimen's protective headgear is completely blocking our sleep inducement methods!</span>")
+			to_chat(user, "<span class='warning'>Nakrycie głowy osobnika całkowicie uniemożliwia pozbawiania go przytomności!</span>")
 			L.visible_message("<span class='danger'>[user] tried to induce sleep in [L] with [src], but [L.p_their()] headgear completely protected [L.p_them()]!</span>", \
-								"<span class='userdanger'>Any sense of drowsiness is quickly diminished as your headgear deflects the effects!</span>")
+								"<span class='userdanger'>Wszelkie uczucie senności szybko znika dzięki twojemu nakryciu głowy, które całkowicie odbija efekt!</span>")
 			return
 		L.drowsyness += 1
-		to_chat(user, "<span class='warning'>Sleep inducement works fully only on stunned specimens! </span>")
+		to_chat(user, "<span class='warning'>Pozbawienie przytomności działa tylko na w pełni ogłuszone osobniki! </span>")
 		L.visible_message("<span class='danger'>[user] tried to induce sleep in [L] with [src]!</span>", \
-							"<span class='userdanger'>You suddenly feel drowsy!</span>")
+							"<span class='userdanger'>Nagle czujesz się bardzo senny!</span>")
 
 /obj/item/abductor/baton/proc/CuffAttack(mob/living/L,mob/living/user)
 	if(!iscarbon(L))
@@ -554,7 +551,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		if(C.get_num_arms(FALSE) >= 2 || C.get_arm_ignore())
 			playsound(src, 'sound/weapons/cablecuff.ogg', 30, TRUE, -2)
 			C.visible_message("<span class='danger'>[user] begins restraining [C] with [src]!</span>", \
-									"<span class='userdanger'>[user] begins shaping an energy field around your hands!</span>")
+									"<span class='userdanger'>[user] zaczyna tworzyć pole energetyczne wokoło twoich rąk!</span>")
 			if(do_mob(user, C, 30) && (C.get_num_arms(FALSE) >= 2 || C.get_arm_ignore()))
 				if(!C.handcuffed)
 					C.handcuffed = new /obj/item/restraints/handcuffs/energy/used(C)
@@ -562,16 +559,16 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 					to_chat(user, "<span class='notice'>You restrain [C].</span>")
 					log_combat(user, C, "handcuffed")
 			else
-				to_chat(user, "<span class='warning'>You fail to restrain [C].</span>")
+				to_chat(user, "<span class='warning'>Nie udaje ci się zakuć [C].</span>")
 		else
-			to_chat(user, "<span class='warning'>[C] doesn't have two hands...</span>")
+			to_chat(user, "<span class='warning'>[C] nie posiada dwóch rąk...</span>")
 
 /obj/item/abductor/baton/proc/ProbeAttack(mob/living/L,mob/living/user)
 	L.visible_message("<span class='danger'>[user] probes [L] with [src]!</span>", \
-						"<span class='userdanger'>[user] probes you!</span>")
+						"<span class='userdanger'>[user] sonduje ciebie!</span>")
 
-	var/species = "<span class='warning'>Unknown species</span>"
-	var/helptext = "<span class='warning'>Species unsuitable for experiments.</span>"
+	var/species = "<span class='warning'>Nieznany gatuneks</span>"
+	var/helptext = "<span class='warning'>Gatunek nie nadaje się do eksperymentów.</span>"
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
@@ -580,19 +577,19 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			species = "<span class='warning'>Changeling lifeform</span>"
 		var/obj/item/organ/heart/gland/temp = locate() in H.internal_organs
 		if(temp)
-			helptext = "<span class='warning'>Experimental gland detected!</span>"
+			helptext = "<span class='warning'>Wykryto eksperymentalny gland!</span>"
 		else
 			if (L.getorganslot(ORGAN_SLOT_HEART))
-				helptext = "<span class='notice'>Subject suitable for experiments.</span>"
+				helptext = "<span class='notice'>Obiekt nadaje się do eksperymentów.</span>"
 			else
-				helptext = "<span class='warning'>Subject unsuitable for experiments.</span>"
+				helptext = "<span class='warning'>Obiekt nie nadaje się do eksperymentów.</span>"
 
-	to_chat(user, "<span class='notice'>Probing result:</span>[species]")
+	to_chat(user, "<span class='notice'>Wyniki sondy:</span>[species]")
 	to_chat(user, "[helptext]")
 
 /obj/item/restraints/handcuffs/energy
-	name = "hard-light energy field"
-	desc = "A hard-light field restraining the hands."
+	name = "twarde pole energetyczne"
+	desc = "twarde pole energetyczne służące jak kajdanki."
 	icon_state = "cuff" // Needs sprite
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
@@ -615,17 +612,17 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	. = ..()
 	switch(mode)
 		if(BATON_STUN)
-			. += "<span class='warning'>The baton is in stun mode.</span>"
+			. += "<span class='warning'>Pałka jest w trybie ogłuszania.</span>"
 		if(BATON_SLEEP)
-			. += "<span class='warning'>The baton is in sleep inducement mode.</span>"
+			. += "<span class='warning'>Pałka jest w trybie usypiania.</span>"
 		if(BATON_CUFF)
-			. += "<span class='warning'>The baton is in restraining mode.</span>"
+			. += "<span class='warning'>>Pałka jest w trybie zakuwania.</span>"
 		if(BATON_PROBE)
-			. += "<span class='warning'>The baton is in probing mode.</span>"
+			. += "<span class='warning'>>Pałka jest w trybie sondowania.</span>"
 
 /obj/item/radio/headset/abductor
-	name = "alien headset"
-	desc = "An advanced alien headset designed to monitor communications of human space stations. Why does it have a microphone? No one knows."
+	name = "headset obcych"
+	desc = "Zaawansowany zestaw słuchawkowy Obcych przeznaczony do monitorowania komunikacji ludzkich stacji kosmicznych. Dlaczego ma mikrofon? Nikt nie wie."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "abductor_headset"
 	item_state = "abductor_headset"
@@ -714,8 +711,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	toolspeed = 0.25
 
 /obj/item/clothing/head/helmet/abductor
-	name = "agent headgear"
-	desc = "Abduct with style - spiky style. Prevents digital tracking."
+	name = "hełm agenta"
+	desc = "Porywaj ze stylem - spiczastym stylem. Zapobiega śledzenia przez kamery."
 	icon_state = "alienhelmet"
 	item_state = "alienhelmet"
 	blockTracking = TRUE
@@ -724,15 +721,15 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 // Operating Table / Beds / Lockers
 
 /obj/structure/bed/abductor
-	name = "resting contraption"
-	desc = "This looks similar to contraptions from Earth. Could aliens be stealing our technology?"
+	name = "urządzenie spoczynkowe"
+	desc = "Wygląda podobnie do zwykłych łóżek z Ziemi. Czy to możliwe, że obcy kradną naszą technologię?"
 	icon = 'icons/obj/abductor.dmi'
 	buildstacktype = /obj/item/stack/sheet/mineral/abductor
 	icon_state = "bed"
 
 /obj/structure/table_frame/abductor
-	name = "alien table frame"
-	desc = "A sturdy table frame made from alien alloy."
+	name = "rama stołu obcych
+	desc = "Wytrzymała rama stołu zrobiona ze stopu obcych."
 	icon_state = "alien_frame"
 	framestack = /obj/item/stack/sheet/mineral/abductor
 	framestackamount = 1
@@ -770,8 +767,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			qdel(src)
 
 /obj/structure/table/abductor
-	name = "alien table"
-	desc = "Advanced flat surface technology at work!"
+	name = "stół opcych"
+	desc = "Zaawansowana powieszchnia płaska w praktyce!"
 	icon = 'icons/obj/smooth_structures/alien_table.dmi'
 	icon_state = "alien_table"
 	buildstack = /obj/item/stack/sheet/mineral/abductor
@@ -782,8 +779,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	frame = /obj/structure/table_frame/abductor
 
 /obj/structure/table/optable/abductor
-	name = "alien operating table"
-	desc = "Used for alien medical procedures. The surface is covered in tiny spines."
+	name = "stół operacyjny obcych"
+	desc = "Używany do procedur medycznych obcych. Jego powieszchnia pokryta jest w małych kolcach."
 	frame = /obj/structure/table_frame/abductor
 	buildstack = /obj/item/stack/sheet/mineral/silver
 	framestack = /obj/item/stack/sheet/mineral/abductor
@@ -814,8 +811,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	. = ..()
 
 /obj/structure/closet/abductor
-	name = "alien locker"
-	desc = "Contains secrets of the universe."
+	name = "szafka obcych"
+	desc = "Posiada sekrety wszechświata."
 	icon_state = "abductor"
 	icon_door = "abductor"
 	can_weld_shut = FALSE
@@ -831,8 +828,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	noglass = TRUE
 
 /obj/item/clothing/under/abductor
-	desc = "The most advanced form of jumpsuit known to reality, looks uncomfortable."
-	name = "alien jumpsuit"
+	desc = "Najbardziej zaawansowana forma kombinezonu znana temu światu, wygląda niewygodnie."
+	name = "kombinezon obcych"
 	icon_state = "abductor-suit"
 	item_state = "bl_suit"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 10, rad = 0, fire = 0, acid = 0)

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -161,7 +161,7 @@
 			continue
 		switch(pick(1,3))
 			if(1)
-				to_chat(H, "<span class='userdanger'>Słyszysz głośny brzęk w głowie, wyciszając twoje myśli!</span>")
+				to_chat(H, "<span class='userdanger'>Słyszysz głośny brzęk w głowie, który wycisza twoje myśli!</span>")
 				H.Stun(50)
 			if(2)
 				to_chat(H, "<span class='warning'>Słyszysz denerwujący brzęk w swojej głowie.</span>")

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -1,11 +1,11 @@
 /obj/item/organ/heart/gland
-	name = "fleshy mass"
-	desc = "A nausea-inducing hunk of twisting flesh and metal."
+	name = "mięsista masa"
+	desc = "Wywołujący mdłości kawałek skręcającego się ciała i metalu."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "gland"
 	status = ORGAN_ROBOTIC
 	beating = TRUE
-	var/true_name = "baseline placebo referencer"
+	var/true_name = "podstawowy placebo-odwoływacz"
 	var/cooldown_low = 300
 	var/cooldown_high = 300
 	var/next_activation = 0
@@ -24,7 +24,7 @@
 /obj/item/organ/heart/gland/examine(mob/user)
 	. = ..()
 	if((user.mind && HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_SCIENTIST_TRAINING)) || isobserver(user))
-		. += "<span class='notice'>It is \a [true_name].</span>"
+		. += "<span class='notice'>Jest to [true_name].</span>"
 
 /obj/item/organ/heart/gland/proc/ownerCheck()
 	if(ishuman(owner))
@@ -54,7 +54,7 @@
 	if(!ownerCheck() || !mind_control_uses || active_mind_control)
 		return
 	mind_control_uses--
-	to_chat(owner, "<span class='userdanger'>You suddenly feel an irresistible compulsion to follow an order...</span>")
+	to_chat(owner, "<span class='userdanger'>Nagle czujesz nieodparty przymus wykonania rozkazu...</span>")
 	to_chat(owner, "<span class='mind_control'>[command]</span>")
 	active_mind_control = TRUE
 	log_admin("[key_name(user)] sent an abductor mind control message to [key_name(owner)]: [command]")
@@ -66,7 +66,7 @@
 /obj/item/organ/heart/gland/proc/clear_mind_control()
 	if(!ownerCheck() || !active_mind_control)
 		return
-	to_chat(owner, "<span class='userdanger'>You feel the compulsion fade, and you <i>completely forget</i> about your previous orders.</span>")
+	to_chat(owner, "<span class='userdanger'>Czujesz, że przymus zanika, a ty <i>całkowicie zapominasz</i> o swoich poprzednich rozkazach.</span>")
 	owner.clear_alert("mind_control")
 	active_mind_control = FALSE
 
@@ -116,7 +116,7 @@
 	mind_control_duration = 3000
 
 /obj/item/organ/heart/gland/heals/activate()
-	to_chat(owner, "<span class='notice'>You feel curiously revitalized.</span>")
+	to_chat(owner, "<span class='notice'>Czujesz się zadziwiająco żywy.</span>")
 	owner.adjustToxLoss(-20, FALSE, TRUE)
 	owner.heal_bodypart_damage(20, 20, 0, TRUE)
 	owner.adjustOxyLoss(-20)
@@ -136,7 +136,7 @@
 	owner.grant_language(/datum/language/slime)
 
 /obj/item/organ/heart/gland/slime/activate()
-	to_chat(owner, "<span class='warning'>You feel nauseated!</span>")
+	to_chat(owner, "<span class='warning'>Masz mdłości!</span>")
 	owner.vomit(20)
 
 	var/mob/living/simple_animal/slime/Slime = new(get_turf(owner), "grey")
@@ -153,7 +153,7 @@
 	mind_control_duration = 6000
 
 /obj/item/organ/heart/gland/mindshock/activate()
-	to_chat(owner, "<span class='notice'>You get a headache.</span>")
+	to_chat(owner, "<span class='notice'>Dostajesz bólu głowy.</span>")
 
 	var/turf/T = get_turf(owner)
 	for(var/mob/living/carbon/H in orange(4,T))
@@ -161,10 +161,10 @@
 			continue
 		switch(pick(1,3))
 			if(1)
-				to_chat(H, "<span class='userdanger'>You hear a loud buzz in your head, silencing your thoughts!</span>")
+				to_chat(H, "<span class='userdanger'>Słyszysz głośny brzęk w głowie, wyciszając twoje myśli!</span>")
 				H.Stun(50)
 			if(2)
-				to_chat(H, "<span class='warning'>You hear an annoying buzz in your head.</span>")
+				to_chat(H, "<span class='warning'>Słyszysz denerwujący brzęk w swojej głowie.</span>")
 				H.confused += 15
 				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 160)
 			if(3)
@@ -181,7 +181,7 @@
 	mind_control_duration = 300
 
 /obj/item/organ/heart/gland/pop/activate()
-	to_chat(owner, "<span class='notice'>You feel unlike yourself.</span>")
+	to_chat(owner, "<span class='notice'>Czujesz, że nie jesteś sobą.</span>")
 	randomize_human(owner)
 	var/species = pick(list(/datum/species/human, /datum/species/lizard, /datum/species/moth, /datum/species/fly))
 	owner.set_species(species)
@@ -196,7 +196,7 @@
 	mind_control_duration = 1800
 
 /obj/item/organ/heart/gland/ventcrawling/activate()
-	to_chat(owner, "<span class='notice'>You feel very stretchy.</span>")
+	to_chat(owner, "<span class='notice'>Czujesz się bardzo elastyczny.</span>")
 	owner.ventcrawler = VENTCRAWLER_ALWAYS
 
 /obj/item/organ/heart/gland/viral
@@ -209,7 +209,7 @@
 	mind_control_duration = 1800
 
 /obj/item/organ/heart/gland/viral/activate()
-	to_chat(owner, "<span class='warning'>You feel sick.</span>")
+	to_chat(owner, "<span class='warning'>Czujesz się chory.</span>")
 	var/datum/disease/advance/A = random_virus(pick(2,6),6)
 	A.carrier = TRUE
 	owner.ForceContractDisease(A, FALSE, TRUE)
@@ -244,7 +244,7 @@
 	mind_control_duration = 1800
 
 /obj/item/organ/heart/gland/trauma/activate()
-	to_chat(owner, "<span class='warning'>You feel a spike of pain in your head.</span>")
+	to_chat(owner, "<span class='warning'>Czujesz nagły, ostry ból w głowie.</span>")
 	if(prob(33))
 		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_LOBOTOMY))
 	else
@@ -263,10 +263,10 @@
 	mind_control_duration = 2400
 
 /obj/item/organ/heart/gland/spiderman/activate()
-	to_chat(owner, "<span class='warning'>You feel something crawling in your skin.</span>")
+	to_chat(owner, "<span class='warning'>Czujesz coś pełzającego w twojej skórze.</span>")
 	owner.faction |= "spiders"
 	var/obj/structure/spider/spiderling/S = new(owner.drop_location())
-	S.directive = "Protect your nest inside [owner.real_name]."
+	S.directive = "Chroń swojego gniazda w środku [owner.real_name]."
 
 /obj/item/organ/heart/gland/egg
 	true_name = "roe/enzymatic synthesizer"
@@ -302,7 +302,7 @@
 
 /obj/item/organ/heart/gland/electric/activate()
 	owner.visible_message("<span class='danger'>[owner]'s skin starts emitting electric arcs!</span>",\
-	"<span class='warning'>You feel electric energy building up inside you!</span>")
+	"<span class='warning'>Czujesz, że energia elektryczna zbiera się w środku twojego ciała!</span>")
 	playsound(get_turf(owner), "sparks", 100, 1, -1)
 	addtimer(CALLBACK(src, .proc/zap), rand(30, 100))
 
@@ -339,8 +339,8 @@
 	mind_control_duration = 800
 
 /obj/item/organ/heart/gland/plasma/activate()
-	to_chat(owner, "<span class='warning'>You feel bloated.</span>")
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, owner, "<span class='userdanger'>A massive stomachache overcomes you.</span>"), 150)
+	to_chat(owner, "<span class='warning'>Czujesz się nadęty..</span>")
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, owner, "<span class='userdanger'>Ogromny ból brzucha cię pokonuje. Czujesz, że zaraz zwymiotujesz!</span>"), 150)
 	addtimer(CALLBACK(src, .proc/vomit_plasma), 200)
 
 /obj/item/organ/heart/gland/plasma/proc/vomit_plasma()

--- a/code/modules/antagonists/abductor/ice_abductor.dm
+++ b/code/modules/antagonists/abductor/ice_abductor.dm
@@ -1,6 +1,6 @@
 /obj/structure/fluff/iced_abductor ///Unless more non-machine ayy structures made, it will stay in fluff.
-	name = "Mysterious Block of Ice"
-	desc = "A shadowy figure lies in this sturdy-looking block of ice. Who knows where it came from?"
+	name = "Tajemnicza Bryła Lodu"
+	desc = "Cienista postać leży w tym solidnie wyglądającym bloku lodu. Kto wie, skąd to się wzięło?"
 	icon = 'icons/effects/freeze.dmi'
 	icon_state =  "ice_ayy"
 	density = TRUE

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -1,5 +1,5 @@
 /obj/machinery/computer/camera_advanced/abductor
-	name = "Human Observation Console"
+	name = "Konsola Obserwacji Ludzi"
 	var/team_number = 0
 	networks = list("ss13", "abductor")
 	var/datum/action/innate/teleport_in/tele_in_action = new
@@ -59,7 +59,7 @@
 	return HAS_TRAIT(H, TRAIT_ABDUCTOR_SCIENTIST_TRAINING)
 
 /datum/action/innate/teleport_in
-	name = "Send To"
+	name = "Wyślij Do"
 	icon_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	button_icon_state = "beam_down"
 
@@ -74,7 +74,7 @@
 		P.PadToLoc(remote_eye.loc)
 
 /datum/action/innate/teleport_out
-	name = "Retrieve"
+	name = "Odbierz"
 	icon_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	button_icon_state = "beam_up"
 
@@ -86,7 +86,7 @@
 	console.TeleporterRetrieve()
 
 /datum/action/innate/teleport_self
-	name = "Send Self"
+	name = "Wyślij Siebię"
 	icon_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	button_icon_state = "beam_down"
 
@@ -101,7 +101,7 @@
 		P.MobToLoc(remote_eye.loc,C)
 
 /datum/action/innate/vest_mode_swap
-	name = "Switch Vest Mode"
+	name = "Zmień Tryb Kamizelki"
 	icon_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	button_icon_state = "vest_mode"
 
@@ -113,7 +113,7 @@
 
 
 /datum/action/innate/vest_disguise_swap
-	name = "Switch Vest Disguise"
+	name = "Zmień Przebranie"
 	icon_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	button_icon_state = "vest_disguise"
 
@@ -124,7 +124,7 @@
 	console.SelectDisguise(remote=1)
 
 /datum/action/innate/set_droppoint
-	name = "Set Experiment Release Point"
+	name = "Umieść Punkt Wypuszczania Eksperymentów"
 	icon_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	button_icon_state = "set_drop"
 

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -59,7 +59,7 @@
 	return HAS_TRAIT(H, TRAIT_ABDUCTOR_SCIENTIST_TRAINING)
 
 /datum/action/innate/teleport_in
-	name = "Wyślij Do"
+	name = "Wyślij"
 	icon_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	button_icon_state = "beam_down"
 

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -86,7 +86,7 @@
 	console.TeleporterRetrieve()
 
 /datum/action/innate/teleport_self
-	name = "Wyślij Siebię"
+	name = "Wyślij Siebie"
 	icon_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 	button_icon_state = "beam_down"
 

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -12,8 +12,8 @@
 //Console
 
 /obj/machinery/abductor/console
-	name = "abductor console"
-	desc = "Ship command center."
+	name = "konsola porywaczy"
+	desc = "Centrum Dowodzenia Statkiem."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "console"
 	density = TRUE
@@ -29,7 +29,7 @@
 	if(.)
 		return
 	if(!HAS_TRAIT(user, TRAIT_ABDUCTOR_TRAINING) && !HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_TRAINING))
-		to_chat(user, "<span class='warning'>You start mashing alien buttons at random!</span>")
+		to_chat(user, "<span class='warning'>Zaczynasz wciskać obce przyciski na chybił trafił!</span>")
 		if(do_after(user,100, target = src))
 			TeleporterSend()
 		return
@@ -40,46 +40,46 @@
 	if(experiment)
 		var/points = experiment.points
 		var/credits = experiment.credits
-		dat += "Collected Samples : [points] <br>"
-		dat += "Gear Credits: [credits] <br>"
-		dat += "<b>Transfer data in exchange for supplies:</b><br>"
-		dat += "<a href='?src=[REF(src)];dispense=baton'>Advanced Baton (2 Credits)</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=mind_device'>Mental Interface Device (2 Credits)</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=chem_dispenser'>Reagent Synthesizer (2 Credits)</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=helmet'>Agent Helmet</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=vest'>Agent Vest</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=silencer'>Radio Silencer</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=tool'>Science Tool</A><br>"
+		dat += "Zebrane Próbki : [points] <br>"
+		dat += "Kredyty Wyposażenia: [credits] <br>"
+		dat += "<b>Prześlij dane w zamian za zasoby:</b><br>"
+		dat += "<a href='?src=[REF(src)];dispense=baton'>Zaawansowana Pałka (2 Kredyty)</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=mind_device'>Interfejs Mentalny (2 Kredyty)</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=chem_dispenser'>Reagent Synthesizer (2 Kredyty)</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=helmet'>Hełm Agentaqt</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=vest'>Kamizelka Agenta</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=silencer'>Uciszacz Radiowy</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=tool'>Narzędzie Naukowe/A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=tongue'>Superlingual Matrix</a><br>"
 	else
-		dat += "<span class='bad'>NO EXPERIMENT MACHINE DETECTED</span> <br>"
+		dat += "<span class='bad'>NIE WYKRYTO MASZYNY EKSPERYMENTACYJNEJ</span> <br>"
 
 	if(pad)
-		dat += "<span class='bad'>Emergency Teleporter System.</span>"
-		dat += "<span class='bad'>Consider using primary observation console first.</span>"
-		dat += "<a href='?src=[REF(src)];teleporter_send=1'>Activate Teleporter</A><br>"
+		dat += "<span class='bad'>Awaryjny System Teleportacyjny.</span>"
+		dat += "<span class='bad'>Najpierw rozważ użycie głównej konsoli obserwacyjnej.</span>"
+		dat += "<a href='?src=[REF(src)];teleporter_send=1'>Aktywuj Teleporter</A><br>"
 		if(gizmo?.marked)
-			dat += "<a href='?src=[REF(src)];teleporter_retrieve=1'>Retrieve Mark</A><br>"
+			dat += "<a href='?src=[REF(src)];teleporter_retrieve=1'>Odzyskaj Oznaczony Cel</A><br>"
 		else
-			dat += "<span class='linkOff'>Retrieve Mark</span><br>"
+			dat += "<span class='linkOff'>Odzyskaj Oznaczony Cel</span><br>"
 	else
-		dat += "<span class='bad'>NO TELEPAD DETECTED</span></br>"
+		dat += "<span class='bad'>NIE WYKRYTO TELEPADA</span></br>"
 
 	if(vest)
-		dat += "<h4> Agent Vest Mode </h4><br>"
+		dat += "<h4> Tryb Kamizelki Agenta </h4><br>"
 		var/mode = vest.mode
 		if(mode == VEST_STEALTH)
 			dat += "<a href='?src=[REF(src)];flip_vest=1'>Combat</A>"
-			dat += "<span class='linkOff'>Stealth</span>"
+			dat += "<span class='linkOff'>Maskowanie</span>"
 		else
-			dat += "<span class='linkOff'>Combat</span>"
+			dat += "<span class='linkOff'>Walka</span>"
 			dat += "<a href='?src=[REF(src)];flip_vest=1'>Stealth</A>"
 
 		dat+="<br>"
-		dat += "<a href='?src=[REF(src)];select_disguise=1'>Select Agent Vest Disguise</a><br>"
-		dat += "<a href='?src=[REF(src)];toggle_vest=1'>[HAS_TRAIT_FROM(vest, TRAIT_NODROP, ABDUCTOR_VEST_TRAIT) ? "Unlock" : "Lock"] Vest</a><br>"
+		dat += "<a href='?src=[REF(src)];select_disguise=1'>Wybierz Przebranie Kamizelki Agenta</a><br>"
+		dat += "<a href='?src=[REF(src)];toggle_vest=1'>[HAS_TRAIT_FROM(vest, TRAIT_NODROP, ABDUCTOR_VEST_TRAIT) ? "Odblokuj" : "Zablokuj"] Kamizelkę</a><br>"
 	else
-		dat += "<span class='bad'>NO AGENT VEST DETECTED</span>"
+		dat += "<span class='bad'>NIE WYKRYTO KAMIZELKI AGENTA</span>"
 	var/datum/browser/popup = new(user, "computer", "Abductor Console", 400, 500)
 	popup.set_content(dat)
 	popup.open()
@@ -152,12 +152,12 @@
 
 /obj/machinery/abductor/console/proc/SetDroppoint(turf/open/location,user)
 	if(!istype(location))
-		to_chat(user, "<span class='warning'>That place is not safe for the specimen.</span>")
+		to_chat(user, "<span class='warning'>Te miejsce nie jest bezpieczne dla obiektu testowego.</span>")
 		return
 
 	if(pad)
 		pad.teleport_target = location
-		to_chat(user, "<span class='notice'>Location marked as test subject release point.</span>")
+		to_chat(user, "<span class='notice'>Lokacja oznaczona jako miejsce wypuszczania obiektów testowych.</span>")
 
 
 /obj/machinery/abductor/console/Initialize(mapload)
@@ -185,7 +185,7 @@
 
 /obj/machinery/abductor/console/proc/AddSnapshot(mob/living/carbon/human/target)
 	if(istype(target.get_item_by_slot(SLOT_HEAD), /obj/item/clothing/head/foilhat))
-		say("Subject wearing specialized protective headgear, unable to get a proper scan!")
+		say("Obiekt nosi specjalne ochronne nakrycie głowy, skanowanie nie jest możliwe!")
 		return
 	var/datum/icon_snapshot/entry = new
 	entry.name = target.name
@@ -223,9 +223,9 @@
 
 /obj/machinery/abductor/console/attackby(obj/O, mob/user, params)
 	if(istype(O, /obj/item/abductor/gizmo) && AddGizmo(O))
-		to_chat(user, "<span class='notice'>You link the tool to the console.</span>")
+		to_chat(user, "<span class='notice'>Łączysz narzędzie z konsolą.</span>")
 	else if(istype(O, /obj/item/clothing/suit/armor/abductor/vest) && AddVest(O))
-		to_chat(user, "<span class='notice'>You link the vest to the console.</span>")
+		to_chat(user, "<span class='notice'>Łączysz kamizelkę z konsolą.</span>")
 	else
 		return ..()
 
@@ -234,7 +234,7 @@
 /obj/machinery/abductor/console/proc/Dispense(item,cost=1)
 	if(experiment && experiment.credits >= cost)
 		experiment.credits -=cost
-		say("Incoming supply!")
+		say("Nadlatuje Dostawa!")
 		var/drop_location = loc
 		if(pad)
 			flick("alien-pad", pad)
@@ -242,4 +242,4 @@
 		new item(drop_location)
 
 	else
-		say("Insufficent data!")
+		say("Niewystarczająca ilość danych!")

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -49,7 +49,7 @@
 		dat += "<a href='?src=[REF(src)];dispense=helmet'>Hełm Agentaqt</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=vest'>Kamizelka Agenta</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=silencer'>Uciszacz Radiowy</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=tool'>Narzędzie Naukowe/A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=tool'>Narzędzie Naukowe</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=tongue'>Superlingual Matrix</a><br>"
 	else
 		dat += "<span class='bad'>NIE WYKRYTO MASZYNY EKSPERYMENTACYJNEJ</span> <br>"

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -1,6 +1,6 @@
 /obj/machinery/abductor/gland_dispenser
-	name = "replacement organ storage"
-	desc = "A tank filled with replacement organs."
+	name = "magazyn organów zastępczych"
+	desc = "Zbiornik wypełniony organami zastępczymis."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "dispenser"
 	density = TRUE

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -1,6 +1,6 @@
 /obj/machinery/abductor/gland_dispenser
 	name = "magazyn organów zastępczych"
-	desc = "Zbiornik wypełniony organami zastępczymis."
+	desc = "Zbiornik wypełniony organami zastępczymi."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "dispenser"
 	density = TRUE

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -163,7 +163,7 @@
 
 	var/datum/antagonist/abductor/user_abductor = user.mind.has_antag_datum(/datum/antagonist/abductor)
 	if(!user_abductor)
-		return "<span class='bad'>Błąd Autoryzacji. Skontaktuj się z Statkiem Matką.</span>"
+		return "<span class='bad'>Błąd Autoryzacji. Skontaktuj się ze Statkiem Matką.</span>"
 
 	var/point_reward = 0
 	if(H in history)

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -1,6 +1,6 @@
 /obj/machinery/abductor/experiment
 	name = "maszyna eksperymentacyjna"
-	desc = Duża, wielkości człowieka rurka ze skomplikowanym układem maszyn chirurgicznych."
+	desc = "Duża, wielkości człowieka rurka ze skomplikowanym układem maszyn chirurgicznych."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "experiment-open"
 	density = FALSE

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -1,6 +1,6 @@
 /obj/machinery/abductor/experiment
-	name = "experimentation machine"
-	desc = "A large man-sized tube sporting a complex array of surgical machinery."
+	name = "maszyna eksperymentacyjna"
+	desc = Duża, wielkości człowieka rurka ze skomplikowanym układem maszyn chirurgicznych."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "experiment-open"
 	density = FALSE
@@ -45,7 +45,7 @@
 		return
 	if(message_cooldown <= world.time)
 		message_cooldown = world.time + 50
-		to_chat(user, "<span class='warning'>[src]'s door won't budge!</span>")
+		to_chat(user, "<span class='warning'>Drzwi maszyny nie chcą się ruszyć!</span>")
 
 /obj/machinery/abductor/experiment/container_resist(mob/living/user)
 	user.changeNext_move(CLICK_CD_BREAKOUT)
@@ -106,31 +106,31 @@
 		dat += "<table><tr><td>"
 		dat += "<img src=dissection_img height=80 width=80>" //Avert your eyes
 		dat += "</td><td>"
-		dat += "<a href='?src=[REF(src)];experiment=1'>Probe</a><br>"
-		dat += "<a href='?src=[REF(src)];experiment=2'>Dissect</a><br>"
-		dat += "<a href='?src=[REF(src)];experiment=3'>Analyze</a><br>"
+		dat += "<a href='?src=[REF(src)];experiment=1'>Sonduj</a><br>"
+		dat += "<a href='?src=[REF(src)];experiment=2'>Przeprowadź Sekcję</a><br>"
+		dat += "<a href='?src=[REF(src)];experiment=3'>Analizuj</a><br>"
 		dat += "</td></tr></table>"
 	else
-		dat += "<span class='linkOff'>Experiment </span>"
+		dat += "<span class='linkOff'>Eksperymentuj </span>"
 
 	if(!occupant)
-		dat += "<h3>Machine Unoccupied</h3>"
+		dat += "<h3>Maszyna Jest Wolna</h3>"
 	else
-		dat += "<h3>Subject Status : </h3>"
+		dat += "<h3>Status Obiektu : </h3>"
 		dat += "[occupant.name] => "
 		var/mob/living/mob_occupant = occupant
 		switch(mob_occupant.stat)
 			if(CONSCIOUS)
-				dat += "<span class='good'>Conscious</span>"
+				dat += "<span class='good'>Przytomny</span>"
 			if(UNCONSCIOUS)
-				dat += "<span class='average'>Unconscious</span>"
+				dat += "<span class='average'>Nieprzytomnys</span>"
 			else // DEAD
-				dat += "<span class='bad'>Deceased</span>"
+				dat += "<span class='bad'>Martwy</span>"
 	dat += "<br>"
 	dat += "[flash]"
 	dat += "<br>"
-	dat += "<a href='?src=[REF(src)];refresh=1'>Scan</a>"
-	dat += "<a href='?src=[REF(src)];[state_open ? "close=1'>Close</a>" : "open=1'>Open</a>"]"
+	dat += "<a href='?src=[REF(src)];refresh=1'>Skanuj</a>"
+	dat += "<a href='?src=[REF(src)];[state_open ? "close=1'>Zamknij</a>" : "open=1'>Otwórz</a>"]"
 	var/datum/browser/popup = new(user, "experiment", "Probing Console", 300, 300)
 	popup.set_title_image(user.browse_rsc_icon(icon, icon_state))
 	popup.set_content(dat)
@@ -163,31 +163,31 @@
 
 	var/datum/antagonist/abductor/user_abductor = user.mind.has_antag_datum(/datum/antagonist/abductor)
 	if(!user_abductor)
-		return "<span class='bad'>Authorization failure. Contact mothership immidiately.</span>"
+		return "<span class='bad'>Błąd Autoryzacji. Skontaktuj się z Statkiem Matką.</span>"
 
 	var/point_reward = 0
 	if(H in history)
-		return "<span class='bad'>Specimen already in database.</span>"
+		return "<span class='bad'>Obiekt jest już w bazie danych.</span>"
 	if(H.stat == DEAD)
-		say("Specimen deceased - please provide fresh sample.")
+		say("Obiekt zmarł - prosimy o dostarczenie świeżej próbki.")
 		return "<span class='bad'>Specimen deceased.</span>"
 	var/obj/item/organ/heart/gland/GlandTest = locate() in H.internal_organs
 	if(!GlandTest)
-		say("Experimental dissection not detected!")
-		return "<span class='bad'>No glands detected!</span>"
+		say("Dysekcja eksperymentalna nie została wykryta!")
+		return "<span class='bad'>Nie wykryto glandu!</span>"
 	if(H.mind != null && H.ckey != null)
 		LAZYINITLIST(abductee_minds)
 		LAZYADD(history, H)
 		LAZYADD(abductee_minds, H.mind)
-		say("Processing specimen...")
+		say("Przetwarzanie obiektu...")
 		sleep(5)
 		switch(text2num(type))
 			if(1)
-				to_chat(H, "<span class='warning'>You feel violated.</span>")
+				to_chat(H, "<span class='warning'>Czujesz się naruszony.</span>")
 			if(2)
-				to_chat(H, "<span class='warning'>You feel yourself being sliced apart and put back together.</span>")
+				to_chat(H, "<span class='warning'>Czujesz się pokrojony na kawałki i poskładany z powrotem.</span>")
 			if(3)
-				to_chat(H, "<span class='warning'>You feel intensely watched.</span>")
+				to_chat(H, "<span class='warning'>Czujesz się intensywnie obserwowany.</span>")
 		sleep(5)
 		user_abductor.team.abductees += H.mind
 		H.mind.add_antag_datum(/datum/antagonist/abductee)
@@ -201,15 +201,15 @@
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 			points += point_reward
 			credits += point_reward
-			return "<span class='good'>Experiment successful! [point_reward] new data-points collected.</span>"
+			return "<span class='good'>Eksperyment zakończony sukcesem! Liczba dodanych punktów danych wynosi: [point_reward].</span>"
 		else
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 1)
-			return "<span class='bad'>Experiment failed! No replacement organ detected.</span>"
+			return "<span class='bad'>Eksperyment się nie powiódł! Nie wykryto żadnego organu zastępczego.</span>"
 	else
-		say("Brain activity nonexistent - disposing sample...")
+		say("Brak aktywności mózgowej - pozbywanie się próbki w toku...")
 		open_machine()
 		SendBack(H)
-		return "<span class='bad'>Specimen braindead - disposed.</span>"
+		return "<span class='bad'>Obiekt bez aktywności mózgowej został wydalony pomyślnie.</span>"
 
 
 /obj/machinery/abductor/experiment/proc/SendBack(mob/living/carbon/human/H)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -1,6 +1,6 @@
 /obj/machinery/abductor/pad
-	name = "Alien Telepad"
-	desc = "Use this to transport to and from the humans' habitat."
+	name = "Telepad Obcych"
+	desc = "Użyj tego by podróżować pomiędzy statkiem a habitatem ludzi."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "alien-pad-idle"
 	var/turf/teleport_target
@@ -16,7 +16,7 @@
 	for(var/mob/living/target in loc)
 		target.forceMove(teleport_target)
 		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
-		to_chat(target, "<span class='warning'>The instability of the warp leaves you disoriented!</span>")
+		to_chat(target, "<span class='warning'>Niestabilność teleportacji pozostawia cię zdezorientowanym!</span>")
 		target.Stun(60)
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)

--- a/html/antagtips/abductor.html
+++ b/html/antagtips/abductor.html
@@ -2,14 +2,14 @@
 	<center>
 	<h1>Jesteś Porywaczem!</h1>
 	<img src="ayylmao.png"/>
-	<p>Ty i twój kolega zostali wybrani przez statek matkę w celu porywania i eksperymentowaniu na ludziach.</p>
+	<p>Ty i twój kolega zostali wybrani przez statek matkę w celu porywania i eksperymentowania na ludziach.</p>
 	<p>Jest was dwóch:</p> 
-	<p><b>naukowiec</b>, którego zadaniem jest podglądać kamery oraz przeprowadzać operację </p>
+	<p><b>naukowiec</b>, którego zadaniem jest podglądać kamery oraz przeprowadzać operację.</p>
 	<p><b>agent</b>, którego zadaniem jest infiltracja stacji, by ogłuszyć i zakuć ludzi.</p>
-	<p><img src="scitool.png"/>Naukowiec musi używać swojej <b>konsoli</b> oraz <b>narzędzia naukowego</b>.Oczekujes, aż agent złapie obiekt testowy po czym wysyła siebie w celu oznaczenia obiektu swoim narzędziem. Następnie odzyskuje cel za pomocą konsoli wraz z agentem.</p>
+	<p><img src="scitool.png"/>Naukowiec musi używać swojej <b>konsoli</b> oraz <b>narzędzia naukowego</b>.Oczekuje, aż agent złapie obiekt testowy po czym wysyła siebie w celu oznaczenia obiektu swoim narzędziem. Następnie odzyskuje cel za pomocą konsoli wraz z agentem.</p>
 	<p><img src="abaton.png"/>Agent musi zostać zesłany przez naukowca, w celu obezwładnienia i zakucia obiektu testowego. Przemieszcza on obiekt w dyskretnie miejsce i oczekuje na naukowca.</p>
 	<p><img src="alienorgan.png"/>Po tym wszystkim, naukowiec przeprowadza <b>experimentation surgery</b>.</p>
 	<p>Ludzie noszący <b>czapeczki foliowe</b> są niewrażliwe na wasze pałki.</p>
-	<p>W celu uzyskania więcej wiadomości odwiedź: <b>https://wiki.beestation13.com/view/Abductor</b></p>	
+	<p>W celu uzyskania więcej wiadomości sprawdź: <b>https://wiki.beestation13.com/view/Abductor</b></p>	
 	</center>
 </html>

--- a/html/antagtips/abductor.html
+++ b/html/antagtips/abductor.html
@@ -8,8 +8,8 @@
 	<p><b>Agent</b>, którego zadaniem jest infiltracja stacji, by ogłuszyć i zakuć ludzi.</p>
 	<p><img src="scitool.png"/>Naukowiec musi używać swojej <b>konsoli</b> oraz <b>narzędzia naukowego</b>.Oczekuje, aż agent złapie obiekt testowy, po czym wysyła siebie w celu oznaczenia obiektu swoim narzędziem. Następnie odzyskuje cel za pomocą konsoli wraz z agentem.</p>
 	<p><img src="abaton.png"/>Agent musi zostać zesłany przez naukowca, w celu obezwładnienia i zakucia obiektu testowego. Przemieszcza on obiekt w dyskretnie miejsce i oczekuje na naukowca.</p>
-	<p><img src="alienorgan.png"/>Po tym wszystkim, naukowiec przeprowadza <b>experimentation surgery</b>.</p>
-	<p>Ludzie noszący <b>czapeczki foliowe</b> są niewrażliwe na wasze pałki.</p>
-	<p>W celu uzyskania więcej wiadomości sprawdź: <b>https://wiki.beestation13.com/view/Abductor</b></p>	
+	<p><img src="alienorgan.png"/>Po tym wszystkim naukowiec przeprowadza <b>experimentation surgery</b>.</p>
+	<p>Ludzie noszący <b>czapeczki foliowe</b> są niewrażliwi na zaawansowane pałki.</p>
+	<p>W celu uzyskania większej ilości informacji, sprawdź: <b>https://wiki.beestation13.com/view/Abductor</b></p>	
 	</center>
 </html>

--- a/html/antagtips/abductor.html
+++ b/html/antagtips/abductor.html
@@ -6,7 +6,7 @@
 	<p>Jest was dwóch:</p> 
 	<p><b>Naukowiec</b>, którego zadaniem jest podglądać kamery oraz przeprowadzać operację.</p>
 	<p><b>Agent</b>, którego zadaniem jest infiltracja stacji, by ogłuszyć i zakuć ludzi.</p>
-	<p><img src="scitool.png"/>Naukowiec musi używać swojej <b>konsoli</b> oraz <b>narzędzia naukowego</b>.Oczekuje, aż agent złapie obiekt testowy po czym wysyła siebie w celu oznaczenia obiektu swoim narzędziem. Następnie odzyskuje cel za pomocą konsoli wraz z agentem.</p>
+	<p><img src="scitool.png"/>Naukowiec musi używać swojej <b>konsoli</b> oraz <b>narzędzia naukowego</b>.Oczekuje, aż agent złapie obiekt testowy, po czym wysyła siebie w celu oznaczenia obiektu swoim narzędziem. Następnie odzyskuje cel za pomocą konsoli wraz z agentem.</p>
 	<p><img src="abaton.png"/>Agent musi zostać zesłany przez naukowca, w celu obezwładnienia i zakucia obiektu testowego. Przemieszcza on obiekt w dyskretnie miejsce i oczekuje na naukowca.</p>
 	<p><img src="alienorgan.png"/>Po tym wszystkim, naukowiec przeprowadza <b>experimentation surgery</b>.</p>
 	<p>Ludzie noszący <b>czapeczki foliowe</b> są niewrażliwe na wasze pałki.</p>

--- a/html/antagtips/abductor.html
+++ b/html/antagtips/abductor.html
@@ -4,8 +4,8 @@
 	<img src="ayylmao.png"/>
 	<p>Ty i twój kolega zostali wybrani przez statek matkę w celu porywania i eksperymentowania na ludziach.</p>
 	<p>Jest was dwóch:</p> 
-	<p><b>naukowiec</b>, którego zadaniem jest podglądać kamery oraz przeprowadzać operację.</p>
-	<p><b>agent</b>, którego zadaniem jest infiltracja stacji, by ogłuszyć i zakuć ludzi.</p>
+	<p><b>Naukowiec</b>, którego zadaniem jest podglądać kamery oraz przeprowadzać operację.</p>
+	<p><b>Agent</b>, którego zadaniem jest infiltracja stacji, by ogłuszyć i zakuć ludzi.</p>
 	<p><img src="scitool.png"/>Naukowiec musi używać swojej <b>konsoli</b> oraz <b>narzędzia naukowego</b>.Oczekuje, aż agent złapie obiekt testowy po czym wysyła siebie w celu oznaczenia obiektu swoim narzędziem. Następnie odzyskuje cel za pomocą konsoli wraz z agentem.</p>
 	<p><img src="abaton.png"/>Agent musi zostać zesłany przez naukowca, w celu obezwładnienia i zakucia obiektu testowego. Przemieszcza on obiekt w dyskretnie miejsce i oczekuje na naukowca.</p>
 	<p><img src="alienorgan.png"/>Po tym wszystkim, naukowiec przeprowadza <b>experimentation surgery</b>.</p>

--- a/html/antagtips/abductor.html
+++ b/html/antagtips/abductor.html
@@ -1,13 +1,15 @@
 <html>
 	<center>
-	<h1>You are an Abductor!</h1>
+	<h1>Jesteś Porywaczem!</h1>
 	<img src="ayylmao.png"/>
-	<p>You and your teammate have been chosen by the mothership to go and capture some humans.</p>
-	<p>There's two of you: the <b>scientist</b>, who must oversee the camera and surgery, and the <b>agent</b>, who must go down on the station to stun and cuff people.</p>
-	<p><img src="scitool.png"/>The scientist must utilize his <b>console</b> and <b>science tool</b>, set to marking mode, to send down the agent, go down himself, mark the target, retrieve it, mark the agent through the console and retrieve him too.</p>
-	<p><img src="alienorgan.png"/>After that, he must do the <b>experimentation surgery</b>.</p>
-	<p><img src="abaton.png"/>The agent must be sent down by the scientist to stun and cuff a target and drag it into a hidden spot and await the scientist.</p>
-	<p>People wearing <b>tinfoil hats</b> are immune to abductor batons.</p>
-	<p>For further information visit <b>https://wiki.beestation13.com/view/Abductor</b></p>	
+	<p>Ty i twój kolega zostali wybrani przez statek matkę w celu porywania i eksperymentowaniu na ludziach.</p>
+	<p>Jest was dwóch:</p> 
+	<p><b>naukowiec</b>, którego zadaniem jest podglądać kamery oraz przeprowadzać operację </p>
+	<p><b>agent</b>, którego zadaniem jest infiltracja stacji, by ogłuszyć i zakuć ludzi.</p>
+	<p><img src="scitool.png"/>Naukowiec musi używać swojej <b>konsoli</b> oraz <b>narzędzia naukowego</b>.Oczekujes, aż agent złapie obiekt testowy po czym wysyła siebie w celu oznaczenia obiektu swoim narzędziem. Następnie odzyskuje cel za pomocą konsoli wraz z agentem.</p>
+	<p><img src="abaton.png"/>Agent musi zostać zesłany przez naukowca, w celu obezwładnienia i zakucia obiektu testowego. Przemieszcza on obiekt w dyskretnie miejsce i oczekuje na naukowca.</p>
+	<p><img src="alienorgan.png"/>Po tym wszystkim, naukowiec przeprowadza <b>experimentation surgery</b>.</p>
+	<p>Ludzie noszący <b>czapeczki foliowe</b> są niewrażliwe na wasze pałki.</p>
+	<p>W celu uzyskania więcej wiadomości odwiedź: <b>https://wiki.beestation13.com/view/Abductor</b></p>	
 	</center>
 </html>

--- a/strings/abductee_objectives.txt
+++ b/strings/abductee_objectives.txt
@@ -1,43 +1,39 @@
-Try to get formally executed for a crime you didn't commit, without a false confession.
-Being alone and in large groups are both frightening.  Try to be alone with only one other person whenever possible.
-No matter how they say it, other people keep mispronouncing your name.  Be sure to correct them whenever possible.
-The Syndicate has hired you to compile dossiers on all important members of the crew. Be sure they don't know you're doing it.
-There is only one other person in existence, he is just really good at pretending to be multiple people.
-There are alien parasites masquerading as people's hair.  Save people from this invasion.
-You died back there and went to heaven... or is it hell? No one here seems to know they're dead. Convince them, and maybe you can escape this limbo.
-You are doomed to feel woefully incomplete forever... until you find your true love on this station. They're waiting for you!
-You're the narrator of this tale. Follow around the protagonists to tell their story.
-The leaders of this station are hiding a grand, evil conspiracy. Only you can learn what it is, and expose it to the people!
-All the pets around here suck. You need to make them cooler. Replace them with exotic beasts!
-You're throwing a huge rager. Make it as awesome as possible so the whole crew comes... OR ELSE!
-The clown is not funny. You can do better! Steal his audience and make the crew laugh!
-You burn with passion for music. Share your vision. If anyone hates it, beat them on the head with your instrument!
-Go have a good conversation with the singularity/tesla/supermatter crystal. Bonus points if it responds.
-You are pregnant and soon due. Find a safe place to deliver your baby.
-Expand the station.
-So much lies undiscovered. Look deeper into the machinations of the universe.
-Climb the corporate ladder all the way to the top!
-Fuck the system! Defect from the station and start an independent colony in space, Lavaland or the derelict. Recruit crewmates if you can.
-Nanotrasen is abusing the animals! Save as many as you can!
-It's all an entirely virtual simulation within an underground vault. Convince the crew to escape the shackles of VR.
-This is a secret social experiment conducted by Nanotrasen. Convince the crew that this is the truth.
-Call forth a spirit from the other side.
-You are secretly an android. Interface with as many machines as you can to boost your own power so the AI may acknowledge you at last.
-The elder gods hunger. Gather a cult and conduct a ritual to summon one.
-You have been changed forever. Find the ones that did this to you and give them a taste of their own medicine.
-Ensure your department prospers over all else.
-The crew must get to know one another better. Break down the walls inside the station!
-The CEO of Nanotrasen is coming! Ensure the station is in absolutely pristine condition.
-Flood the station's powernet with as much electricity as you can.
-Replace all the floor tiles with wood, carpeting, grass or bling.
-You must escape the station! Get the shuttle called!
-Don't allow anyone to be cloned.
-The oxygen is killing them all and they don't even know it. Make sure no oxygen is on the station.
-Your body must be improved. Ingest as many drugs as you can.
-You are hungry. Eat as much food as you can find.
-You see you see what they cannot you see the open door you seeE you SEeEe you SEe yOU seEee SHOW THEM ALL
-Convince the crew that you are a paraplegic.
-Start a collection of corpses. Don't kill people to get these corpses.
-Convince the crew that we are in a game, without explicitly telling them we are in a game.
-You are in a action movie. You must say as many cheesy one liners as possible.
-You are a military instructor. You must make sure the crew is in top shape for the war against the syndicate!
+Postaraj się byś został formalnie stracony za przestępstwo, którego nie popełniłeś, bez fałszywego przyznania się do winy.
+Bycie samemu i w dużych grupach jest przerażające. Staraj się być sam na sam z jedną osobą, kiedy tylko jest to możliwe.
+Nieważne, jak to mówią, inni ludzie wciąż źle wymawiają twoje imię. Poprawiaj ich, gdy tylko jest to możliwe.
+Syndykat zatrudnił cię do sporządzenia dokumentacji dotyczącej wszystkich ważnych członków załogi. Upewnij się, że nie wiedzą, że to robisz.
+Na stacji istnieje tylko jedna inna osoba, jest po prostu naprawdę dobra w udawaniu wielu ludzi.
+Wszyscy posiadają obce pasożyty, maskujące się jak ludzkie włosy. Ocal ich przed tą inwazją!
+Umarłeś i poszedłeś do nieba. . . czy to piekło? Nikt tu chyba nie wie, że nie żyje. Przekonaj ich, a może uda ci się uciec z tego czyśca!
+Jesteś skazany na to, że na zawsze będziesz czuł się żałośnie niekompletny. . . dopóki nie znajdziesz swojej prawdziwej miłości na tej stacji. Oni czekają na ciebie! Jesteś narratorem tej opowieści. Podążaj za bohaterami, by opowiedzieć ich im historię.
+Przywódcy tej stacji ukrywają wielki, zły spisek. Tylko ty możesz dowiedzieć się, co to jest i wyjawić go na światło dzienne!
+Wszystkie zwierzęta na stacji są do bani. Musisz uczynić je fajniejszymi. Wymień je na egzotyczne bestie!
+Jesteś okropnie wściekły! Wyraź swoje zdanie i  zrób to tak niesamowicie, jak to tylko możliwe!
+Klaun nie jest zabawny. Możesz zrobić to lepiej! Ukradnij mu widownię i rozśmiesz załogę!
+Płoniesz z pasją do muzyki. Podziel się swoją wizją. Jeśli komuś się to nie podoba, walnij go w głowę swoim instrumentem!
+Udaj się na dobrą rozmowę z osobliwością/teslą/kryształem supermaterii. Bonusowe punkty, jeśli zareaguje.
+Jesteś w ciąży i niedługo urodzisz. Znajdź bezpieczne miejsce do porodu dziecka.
+Powiększ stację.
+Istnieje wiele zagadek na tym świecie. Przyjrzyj się głębiej machinacjom wszechświata.
+Wspinaj się po drabinie korporacyjnej aż na sam szczyt!
+Pieprzyć system! Ucieknij ze stacji i stwórz niezależną kolonię w kosmosie, na lavalandi lub na innej uszkodzonej stacji. Rekrutuj kolegów z załogi, jeśli możesz.
+Nanotrasen nadużywa zwierząt! Ocal ich tyle, ile możesz!
+To wszystko jest wirtualną symulacją w podziemnym skarbcu. Przekonaj załogę do ucieczki z kajdan VR.
+To wszystko to tajny eksperyment społeczny prowadzony przez Nanotrasen. Przekonaj załogę, że to prawda.
+Wywołaj ducha z drugiej strony.
+Jesteś potajemnie androidem. połącz się z jak największą liczbą maszyn, aby zwiększyć swoją własną moc, tak aby SI mogła w końcu cię zaakceptować.
+Starsi bogowie głodują. Utwórz kult i przeprowadź rytuał, aby ich przywołać.
+Zostałeś zmieniony na zawsze. Znajdź tych, którzy ci to zrobili i daj im posmakować ich własnego lekarstwa!.
+Upewnij się, że twój wydział prosperuje nad wszystkimi innymi.
+Załoga musi się lepiej poznać. Zburz ściany wewnątrz stacji!
+Nadchodzi dyrektor generalny Nanotrasen! Upewnij się, że stacja jest w absolutnie nieskazitelnym stanie.
+Zalej sieć energetyczną stacji ogromną ilością prądu.
+Wymień wszystkie płytki podłogowe na drewniane, wykładzinę, trawę lub bling.
+Musisz uciec ze stacji! Wezwij prom!
+Nie pozwól nikomu zostać sklonowanym.
+Tlen zabija ich wszystkich, a oni nawet o tym nie wiedzą. Upewnij się, że na stacji nie ma tlenu.
+Twoje ciało musi być ulepszone. Połknij tyle narkotyków, ile możesz.
+Jesteś głodny. Jedz tyle jedzenia, ile możesz.
+Widzisz to czego oni nie mogą widzisz otwarte drzwi których widZISZ Ty WIDZisz tY wIwdziSz tYyY WiDZISZ POKAŻ IM WSZYSTKIM
+Przekonaj załogę, że jesteś paraplegikiem. Zacznij zbiórkę zwłok. Nie zabijaj nikogo, by zdobyć te zwłoki.
+Przekonaj załogę, że jesteśmy w grze, nie mówiąc im wprost, że jesteśmy w grze.


### PR DESCRIPTION
ayy lmao

przetłumaczyłem praktycznie wszystko poza visiblemessage, ponieważ nie ma to sensu w tym momencie.
poprawiłem błędy, które udało mi się znaleźć.

## Changelog
:cl:
tweak: Abductorzy to teraz Porywacze, ayy lmao
add: spolszczono okienko startowe, tekst na start, maszynerię, sprzęt porywaczy oraz komunikaty dla gracza.
/:cl:

