### PR TITLE
MINIMUM_AGE dla dronów

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -1,8 +1,8 @@
 GLOBAL_VAR(posibrain_notify_cooldown)
 
 /obj/item/mmi/posibrain
-	name = "positronic brain"
-	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves."
+	name = "mózg pozytronowy"
+	desc = "Kostka z lśniącego metalu pokryta ze wszystkich stron płytkimi żłobieniami."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -14,17 +14,17 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	mecha = null//This does not appear to be used outside of reference in mecha.dm.
 	braintype = "Android"
 	var/autoping = TRUE //if it pings on creation immediately
-	var/begin_activation_message = "<span class='notice'>You carefully locate the manual activation switch and start the positronic brain's boot process.</span>"
-	var/success_message = "<span class='notice'>The positronic brain pings, and its lights start flashing. Success!</span>"
-	var/fail_message = "<span class='notice'>The positronic brain buzzes quietly, and the golden lights fade away. Perhaps you could try again?</span>"
+	var/begin_activation_message = "<span class='notice'>Ostrożnie naciskasz przycisk manualnej aktywacji pozytrona rozpoczynając jego proces aktywacji.</span>"
+	var/success_message = "<span class='notice'>Pozytron wydaje z siebie głośne 'ping' i zaczyna błyszczeć. Sukces!</span>"
+	var/fail_message = "<span class='notice'>Pozytron cichutko buczy, a złote światło zanika. Być może warto spróbować ponownie?</span>"
 	var/new_role = "Positronic Brain"
-	var/welcome_message = "<span class='warning'>ALL PAST LIVES ARE FORGOTTEN.</span>\n\
-	<b>You are a positronic brain, brought into existence aboard Space Station 13.\n\
-	As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
-	Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>"
-	var/new_mob_message = "<span class='notice'>The positronic brain chimes quietly.</span>"
-	var/dead_message = "<span class='deadsay'>It appears to be completely inactive. The reset light is blinking.</span>"
-	var/recharge_message = "<span class='warning'>The positronic brain isn't ready to activate again yet! Give it some time to recharge.</span>"
+	var/welcome_message = "<span class='warning'>NIE PAMIĘTASZ POPRZEDNICH ŻYĆ.</span>\n\
+	<b>Jesteś mózgiem pozytronowym, stworzonym na pokładzie stacji.\n\
+	Jako syntetyczna inteligencja, podlegasz wszystkim istotom na stacji oraz SI.\n\
+	Pamiętaj, istotą Twojego istnienia jest służenie stacji i załodze. Nie wywołuj krzywdy.</b>"
+	var/new_mob_message = "<span class='notice'>Pozytron cicho dzwoni.</span>"
+	var/dead_message = "<span class='deadsay'>Wygląda na całkowicie nieaktywny. Dioda restartu mruga w regularnych interwałach.</span>"
+	var/recharge_message = "<span class='warning'>Pozytron nie jest jeszcze gotowy do restartu!</span>"
 	var/list/possible_names //If you leave this blank, it will use the global posibrain names
 	var/picked_name
 
@@ -44,7 +44,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	if(!brainmob)
 		brainmob = new(src)
 	if(is_occupied())
-		to_chat(user, "<span class='warning'>This [name] is already active!</span>")
+		to_chat(user, "<span class='warning'>Ten [name] jest już aktywne!</span>")
 		return
 	if(next_ask > world.time)
 		to_chat(user, recharge_message)
@@ -88,10 +88,10 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	if(is_occupied() || is_banned_from(user.ckey, ROLE_POSIBRAIN) || QDELETED(brainmob) || QDELETED(src) || QDELETED(user))
 		return
 	if(user.suiciding) //if they suicided, they're out forever.
-		to_chat(user, "<span class='warning'>[src] fizzles slightly. Sadly it doesn't take those who suicided!</span>")
+		to_chat(user, "<span class='warning'>[src] nieco syczy. Niestety, nie akceptuje samobójców!</span>")
 		return
-	var/posi_ask = alert("Become a [name]? (Warning, You can no longer be cloned, and all past lives will be forgotten!)","Are you positive?","Yes","No")
-	if(posi_ask == "No" || QDELETED(src))
+	var/posi_ask = alert("Chcesz grać jako [name]? (UWAGA, nie możesz po tym zostać sklonowany i wszystkie poprzednie życia są zapomniane!)","Czy jesteś pewien?","Tak","Nie")
+	if(posi_ask == "Nie" || QDELETED(src))
 		return
 	if(brainmob.suiciding) //clear suicide status if the old occupant suicided.
 		brainmob.set_suicide(FALSE)
@@ -120,7 +120,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	if(QDELETED(brainmob))
 		return
 	if(is_occupied()) //Prevents hostile takeover if two ghosts get the prompt or link for the same brain.
-		to_chat(candidate, "<span class='warning'>This [name] was taken over before you could get to it! Perhaps it might be available later?</span>")
+		to_chat(candidate, "<span class='warning'>Ten [name] zostało już przejęte! Być może później będzie dostępnych ich więcej?</span>")
 		return FALSE
 	if(candidate.mind && !isobserver(candidate))
 		candidate.mind.transfer_to(brainmob)
@@ -144,9 +144,9 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		switch(brainmob.stat)
 			if(CONSCIOUS)
 				if(!brainmob.client)
-					. += "It appears to be in stand-by mode." //afk
+					. += "Wygląda na to, że jest w trybie czuwania." //afk
 			if(DEAD)
-				. += "<span class='deadsay'>It appears to be completely inactive.</span>"
+				. += "<span class='deadsay'>Wygląda na całkowicie nieaktywne.</span>"
 	else
 		. += "[dead_message]"
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -1,4 +1,4 @@
-#define DRONE_MINIMUM_AGE 14
+#define DRONE_MINIMUM_AGE 7
 
 ///////////////////
 //DRONES AS ITEMS//
@@ -21,7 +21,7 @@
 	. = ..()
 	var/area/A = get_area(src)
 	if(A)
-		notify_ghosts("A drone shell has been created in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_DRONE, notify_suiciders = FALSE)
+		notify_ghosts("Dron został stworzony w [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_DRONE, notify_suiciders = FALSE)
 	GLOB.poi_list |= src
 	if(isnull(possible_seasonal_hats))
 		build_seasonal_hats()
@@ -46,22 +46,22 @@
 	if(CONFIG_GET(flag/use_age_restriction_for_jobs))
 		if(!isnum(user.client.player_age)) //apparently what happens when there's no DB connected. just don't let anybody be a drone without admin intervention
 			return
-		if(user.client.player_age < DRONE_MINIMUM_AGE)
-			to_chat(user, "<span class='danger'>You're too new to play as a drone! Please try again in [DRONE_MINIMUM_AGE - user.client.player_age] days.</span>")
-			return
 	if(!SSticker.mode)
-		to_chat(user, "Can't become a drone before the game has started.")
+		to_chat(user, "Nie możesz być dronem przed początkiem rundy.")
 		return
-	var/be_drone = alert("Become a drone? (Warning, You can no longer be cloned!)",,"Yes","No")
-	if(be_drone == "No" || QDELETED(src) || !isobserver(user))
-		return
-	var/mob/living/simple_animal/drone/D = new drone_type(get_turf(loc))
-	if(!D.default_hatmask && seasonal_hats && possible_seasonal_hats.len)
-		var/hat_type = pick(possible_seasonal_hats)
-		var/obj/item/new_hat = new hat_type(D)
-		D.equip_to_slot_or_del(new_hat, SLOT_HEAD)
-	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
-	D.key = user.key
-	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of \a [src] in [AREACOORD(src)].")
-	log_game("[key_name(user)] has taken possession of \a [src] in [AREACOORD(src)].")
-	qdel(src)
+	if(!(user.client.player_age < DRONE_MINIMUM_AGE))
+		var/be_drone = alert("Czy chcesz zostać dronem? (UWAGA, nie możesz po tym zostać sklonowany!)",,"Tak","Nie")
+		if(be_drone == "Nie" || QDELETED(src) || !isobserver(user))
+			return
+		var/mob/living/simple_animal/drone/D = new drone_type(get_turf(loc))
+		if(!D.default_hatmask && seasonal_hats && possible_seasonal_hats.len)
+			var/hat_type = pick(possible_seasonal_hats)
+			var/obj/item/new_hat = new hat_type(D)
+			D.equip_to_slot_or_del(new_hat, SLOT_HEAD)
+			D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
+		D.key = user.key
+		message_admins("[key_name(D)] has taken possession of \a [src] in [AREACOORD(src)].")
+		log_game("[key_name(user)] has taken possession of \a [src] in [AREACOORD(src)].")
+		qdel(src)
+	else
+		to_chat(user, "<span class='danger'>Jesteś zbyt nowy żeby grać dronem! Spróbuj ponownie za [DRONE_MINIMUM_AGE - user.client.player_age] dni.</span>")

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -74,7 +74,7 @@
 	desc = "Nieaktywny dron naprawczy z wbudowanym holoprojektorem czapek."
 	drone_type = /mob/living/simple_animal/drone/snowflake
 
-/obj/item/drone_shell/attack_ghost(mob/user)
+/obj/item/drone_shell/snowflake/attack_ghost(mob/user)
 	if(is_banned_from(user.ckey, ROLE_DRONE) || QDELETED(src) || QDELETED(user))
 		return
 	if(CONFIG_GET(flag/use_age_restriction_for_jobs))

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -1,3 +1,4 @@
+#define DRONE_MINIMUM_AGE 7
 ////////////////////
 //MORE DRONE TYPES//
 ////////////////////
@@ -73,6 +74,32 @@
 	name = "Nieaktywny holodron"
 	desc = "Nieaktywny dron naprawczy z wbudowanym holoprojektorem czapek."
 	drone_type = /mob/living/simple_animal/drone/snowflake
+
+/obj/item/drone_shell/attack_ghost(mob/user)
+	if(is_banned_from(user.ckey, ROLE_DRONE) || QDELETED(src) || QDELETED(user))
+		return
+	if(CONFIG_GET(flag/use_age_restriction_for_jobs))
+		if(!isnum(user.client.player_age)) //apparently what happens when there's no DB connected. just don't let anybody be a drone without admin intervention
+			return
+	if(!SSticker.mode)
+		to_chat(user, "Nie możesz zostać holodronem przed początkiem rundy.")
+		return
+	if(!(user.client.player_age < DRONE_MINIMUM_AGE))
+		var/be_drone = alert("Czy chcesz zostać holodronem? (UWAGA, nie możesz po tym zostać sklonowany!)",,"Tak","Nie")
+		if(be_drone == "Nie" || QDELETED(src) || !isobserver(user))
+			return
+		var/mob/living/simple_animal/drone/D = new drone_type(get_turf(loc))
+		if(!D.default_hatmask && seasonal_hats && possible_seasonal_hats.len)
+			var/hat_type = pick(possible_seasonal_hats)
+			var/obj/item/new_hat = new hat_type(D)
+			D.equip_to_slot_or_del(new_hat, SLOT_HEAD)
+			D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
+		D.key = user.key
+		message_admins("[key_name(D)] has taken possession of \a [src] in [AREACOORD(src)].")
+		log_game("[key_name(user)] has taken possession of \a [src] in [AREACOORD(src)].")
+		qdel(src)
+	else
+		to_chat(user, "<span class='danger'>Jesteś zbyt nowy żeby grać holodronem! Spróbuj ponownie za [DRONE_MINIMUM_AGE - user.client.player_age] dni.</span>")
 
 /mob/living/simple_animal/drone/polymorphed
 	default_storage = null

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -1,4 +1,3 @@
-#define DRONE_MINIMUM_AGE 7
 ////////////////////
 //MORE DRONE TYPES//
 ////////////////////


### PR DESCRIPTION
# O Pull Requeście
Drony mogą teraz być kontrolowane tylko przez osoby będące na serwerze przynajmniej tydzień.

# Dlaczego to dobre dla gry
Griefers bad, adminlog good

## Changelog
:cl:
add: drony posiadają teraz ograniczenie minimalnego czasu gry na serwerze
spellcheck: tłumaczenia posibraina i dronów
admin: poprawnie loguje i wyświetla ckey osoby przejmującej kontrolę nad dronem w adminlogu.
/:cl: