### PR TITLE
Kolejne buffy dla sec!? Taser Edition

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -5,6 +5,7 @@
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
 	ammo_x_offset = 3
+	pin = null
 
 /obj/item/gun/energy/tesla_revolver
 	name = "tesla gun"
@@ -23,6 +24,7 @@
 	icon_state = "advtaser"
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 2
+	pin = null
 
 /obj/item/gun/energy/e_gun/advtaser/cyborg
 	name = "cyborg taser"
@@ -47,7 +49,7 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = FALSE
 	use_cyborg_cell = TRUE
-	
+
 /obj/item/gun/energy/pulse/carbine/cyborg
 	name = "cyborg pulse carbine"
 	desc = "An integrated pulse rifle"
@@ -60,7 +62,7 @@
 	icon_state = "personal"
 	item_state = "gun"
 	pin = /obj/item/firing_pin/dna //Personal.
-	w_class = WEIGHT_CLASS_SMALL 
+	w_class = WEIGHT_CLASS_SMALL
 	cell_type = /obj/item/stock_parts/cell{charge = 320; maxcharge = 320} //Should be about 8 shots. 3 times less than the regular one.
 	ammo_x_offset = 2
 	charge_sections = 2


### PR DESCRIPTION
# O Pull Requeście
Usuwa specjalnopłateczkowość taserów z techfabu sec pod postacią bycia jedynymi broniami-broniami drukującymi się od razu z firing pinami.

# Dlaczego to dobre dla gry
Consistency good, ponadto byle kto nie może włamać się do sec/ukraść boardu i drukować "i click first so i win" maszynek. Ponadto czerwoni też nie mogą drukować co im się żywnie podoba bez autoryzacji wardena/HoSa tak jak być powinno.

## Changelog
:cl:
fix: usuwa firing piny jako standard po wydrukowaniu tasera oraz advanced tasera
/:cl: