### PR TITLE
Małe poprawki na Kilo Station

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -30336,7 +30336,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "bfx" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -71433,6 +71432,28 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"mgC" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters";
+	name = "Research Privacy Shutter"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Research and Development Desk";
+	req_one_access_txt = "7;29"
+	},
+/turf/open/floor/plating,
+/area/science/lab)
 "mix" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/virology)
@@ -108863,7 +108884,7 @@ ayU
 bco
 bdL
 aYf
-aYK
+mgC
 aYK
 aYd
 bij

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2103,6 +2103,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aer" = (
@@ -3113,7 +3115,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/computer/prisoner,
+/obj/machinery/computer/prisoner/management,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "agv" = (
@@ -7175,7 +7177,9 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
 "aop" = (
-/obj/structure/displaycase/captain,
+/obj/structure/displaycase/captain{
+	req_access_txt = "20"
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
@@ -10423,7 +10427,13 @@
 	dir = 4;
 	icon_state = "scrub_map_on-1"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "avu" = (
 /obj/structure/sign/warning/explosives/alt,
@@ -11609,12 +11619,18 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "axL" = (
-/obj/structure/bodycontainer/morgue,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/brig_phys,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "axM" = (
 /obj/structure/table,
@@ -18390,7 +18406,14 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aKM" = (
 /obj/structure/chair/sofa/left{
@@ -60233,7 +60256,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/computer/prisoner{
+/obj/machinery/computer/prisoner/management{
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -65193,6 +65216,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/processing)


### PR DESCRIPTION
# O Pull Requeście
Małe poprawki na Kilo Station.

Dodano brakujące kable pod prawym skrzydłem AI Satellite:
![obraz](https://user-images.githubusercontent.com/73129727/96490419-11753400-1241-11eb-865a-6ac33aa1eaca.png)

Usunięto jedno morgue w brig phys office i zastąpiono szafką brig physa:
![obraz](https://user-images.githubusercontent.com/73129727/96490564-497c7700-1241-11eb-96f7-2ae622af603f.png)

Dodano brakujący labor camp teleporter przy promie do gułagu w sec. Działa prawidłowo - wysyła na lavaland gulag:
![obraz](https://user-images.githubusercontent.com/73129727/96490671-6a44cc80-1241-11eb-807e-260c8cd18a9b.png)

Poprawiono puste komputery na prisoner management console w sec:
![obraz](https://user-images.githubusercontent.com/73129727/96490750-86486e00-1241-11eb-8b17-aaf549c0f0fc.png)

Kapitan moze teraz otwierać własny displaycase ze swoim lasergunem (tylko dla ACCESS_CAPTAIN).

Dodano publiczne autolathe przy sci:
![obraz](https://user-images.githubusercontent.com/73129727/96496663-cc093480-1249-11eb-92c8-2dc646fb51db.png)



## Changelog
:cl:
fix: dodano brakujące kable pod prawym skrzydłem AI Satellite
add: włączono otwieranie displaycase z pistoletem kapitana via ID kapitana/AA
tweak: usunięto jedno morgue z ambulatorium w sec, zamiast tego stoi tam teraz szafka brig physiciana
fix: wymieniono puste komputery na prisoner management console w sec (biuro wardena - środkowy, przy permabrigu - lewy)
add: dostawiono labor camp teleporter console przy promie do gułagu
add: dodano publiczne autolathe przy sci
/:cl:

