### PR TITLE
fix na jednostrzałowe pulse rifle

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -301,6 +301,7 @@
 /obj/item/stock_parts/cell/pulse //30 pulse shots, used for pulse rifle from which it cannot be removed
 	name = "pulse rifle power cell"
 	maxcharge = 60000
+	chargerate = 5000
 
 /obj/item/stock_parts/cell/pulse/carbine //25 pulse shots
 	name = "pulse carbine power cell"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -298,6 +298,10 @@
 	else
 		add_overlay("mg-cell-o1")
 
+/obj/item/stock_parts/cell/pulse //30 pulse shots, used for pulse rifle from which it cannot be removed
+	name = "pulse rifle power cell"
+	maxcharge = 60000
+
 /obj/item/stock_parts/cell/pulse/carbine //25 pulse shots
 	name = "pulse carbine power cell"
 	maxcharge = 50000

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -298,6 +298,14 @@
 	else
 		add_overlay("mg-cell-o1")
 
+/obj/item/stock_parts/cell/gun/self_recharging //for captain's laser/scattergun, where the battery cannot be ejected
+	name = "self-recharging weapon power cell"
+	icon = 'icons/obj/power.dmi'
+	icon_state = "g-cell"
+	maxcharge = 10000
+	chargerate = 1500
+	self_recharge = TRUE
+
 /obj/item/stock_parts/cell/pulse //30 pulse shots, used for pulse rifle from which it cannot be removed
 	name = "pulse rifle power cell"
 	maxcharge = 60000

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -38,6 +38,8 @@
 	force = 10
 	ammo_x_offset = 3
 	selfcharge = 1
+	internal_cell = TRUE // uses a self-recharging cell which shouldn't be used in other places
+	cell_type = /obj/item/stock_parts/cell/gun/self_recharging
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	weapon_weight = WEAPON_LIGHT
 


### PR DESCRIPTION
# O Pull Requeście
fixes #489 

Domyślny `stock_parts/cell/pulse` który jest włożony w pulse rifle nie ma ustawionego charge, więc dziedziczy z `stock_parts/cell` marne 1000, co wystarcza na jeden strzał na kill.
`stock_parts/cell/pulse` nie jest używany nigdzie indziej, ani nie da się go wymontować z pulse rifle, więc ustawiłem 60000 co daje 60 strzałów na kill, 30 na stun/destroy. 
Chargerate zostaje na 100, żeby nie było zbyt szybkiego ładowania i tak już mocnej broni.


Dodatkowo, dodano nowy typ baterii (`/obj/item/stock_parts/cell/gun/self_recharging`) do laserguna/scattershota kapitana, która sama się ładuje, ale nie da się jej wyciągnąć z nich.

## Changelog
:cl:
fix: naprawa pulse rifle, aby mogło strzelić więcej niż raz
fix: laser i scattershot kapitana same się ładują, zgodnie z opisem
/:cl:


