### PR TITLE
fix zapisywania pozycji kamery dla AI

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -166,8 +166,8 @@
 	builtInCamera.network = list("ss13")
 
 /mob/living/silicon/ai/key_down(_key, client/user)
-	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number
-		_key = _key[7] //strings, lists, same thing really
+	_key = _key[length(_key)] // _key for this one is gonna be either Ctrl-NumpadX, Ctrl-X, NumpadX, or just X - get only X
+
 	switch(_key)
 		if("`", "0")
 			if(cam_prev)
@@ -175,7 +175,7 @@
 			return
 		if("1", "2", "3", "4", "5", "6", "7", "8", "9")
 			_key = text2num(_key)
-			if(client.keys_held["Ctrl"]) //do we assign a new hotkey?
+			if(user.keys_held["Ctrl"]) //do we assign a new hotkey?
 				cam_hotkeys[_key] = eyeobj.loc
 				to_chat(src, "Location saved to Camera Group [_key].")
 				return


### PR DESCRIPTION
# O Pull Requeście
fixes #270 

Wszystko w ww issue jest sprawne (alt-click elektryfikacja, wybór modułów na borgach via 1-3), z wyjątkiem AI camera hotkeyów właśnie. Toto naprawia. 

Śmieszny błąd generalnie, w którymś momencie do `key_down()` zaczęto chyba też przekazywać modyfikatory, więc naciśnięcie Ctrl+1 powoduje przekazanie w `_key` wartości `Ctrl-1`, albo `Ctrl-Numpad1`, co w ogóle nie jest obsłużone w switchu. Własciwy numerek zawsze będzie na końcu danej kombinacji, więc biorę ostatni char z `_key` i tyle.


## Changelog
:cl:
fix: naprawiono hotkeye dla AI do kamer (Ctrl+1-9 / 1-9)
/:cl:

<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
