### PR TITLE
Zakładanie kont bankowych

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -344,8 +344,11 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				carddesc += "<input type='submit' value='Rename' onclick='markGreen()'>"
 				carddesc += "</form>"
 				if(!modify.registered_account)
-					carddesc += "<b>No bank account is assigned to this ID!</b><br>"
-					carddesc += "<a href='?src=[REF(src)];choice=newbankaccount'>Create new bank account and assign it</a><br>"
+					if(target_owner == "--------")
+						carddesc += "<b>No bank account is assigned to this ID!</b> First, rename the ID to create a new account for it.<br>"
+					else
+						carddesc += "<b>No bank account is assigned to this ID!</b><br>"
+						carddesc += "<a href='?src=[REF(src)];choice=newbankaccount'>Create a new bank account and assign it</a><br>"
 				carddesc += "<b>Assignment:</b> "
 
 				jobs += "<span id='alljobsslot'><a href='#' onclick='showAll()'>[target_rank]</a></span>" //CHECK THIS
@@ -466,7 +469,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 		if("newbankaccount")
 			if (authenticated == 2)
-				var/datum/bank_account/bank_account = new /datum/bank_account(modify.registered_name)
+				var/datum/bank_account/bank_account = new /datum/bank_account(modify.registered_name, null) // job=null so it is not added to global acct list/no payday is made for it
 				modify.registered_account = bank_account
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 				to_chat(usr, "New bank account has been registered and assigned to this ID.")

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -258,6 +258,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 		for(var/A in SSeconomy.bank_accounts)
 			var/datum/bank_account/B = A
+			if(!B.account_job)
+				continue	// in case there's no job assigned
 			if(!(B.account_job.paycheck_department in paycheck_departments))
 				continue
 			dat += "<tr>"
@@ -341,6 +343,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				carddesc += "<b>registered name:</b> <input type='text' id='namefield' name='reg' value='[target_owner]' style='width:250px; background-color:white;' onchange='markRed()'>"
 				carddesc += "<input type='submit' value='Rename' onclick='markGreen()'>"
 				carddesc += "</form>"
+				if(!modify.registered_account)
+					carddesc += "<b>No bank account is assigned to this ID!</b><br>"
+					carddesc += "<a href='?src=[REF(src)];choice=newbankaccount'>Create new bank account and assign it</a><br>"
 				carddesc += "<b>Assignment:</b> "
 
 				jobs += "<span id='alljobsslot'><a href='#' onclick='showAll()'>[target_rank]</a></span>" //CHECK THIS
@@ -458,6 +463,15 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 						if(access_allowed == 1)
 							modify.access += access_type
 						playsound(src, "terminal_type", 50, 0)
+
+		if("newbankaccount")
+			if (authenticated == 2)
+				var/datum/bank_account/bank_account = new /datum/bank_account(modify.registered_name)
+				modify.registered_account = bank_account
+				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
+				to_chat(usr, "New bank account has been registered and assigned to this ID.")
+				to_chat(usr, "<span class='warning'>Please keep in mind that only registered Nanotrasen employees are eligible for automated salary payouts.</span>")
+
 		if ("assign")
 			if (authenticated == 2)
 				var/t1 = href_list["assign_target"]

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -258,8 +258,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 		for(var/A in SSeconomy.bank_accounts)
 			var/datum/bank_account/B = A
-			if(!B.account_job)
-				continue	// in case there's no job assigned
 			if(!(B.account_job.paycheck_department in paycheck_departments))
 				continue
 			dat += "<tr>"

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -21,7 +21,8 @@
 	account_holder = newname
 	account_job = job
 	account_id = rand(111111,999999)
-	paycheck_amount = account_job.paycheck
+	if(account_job) // job might not have been provided - account with no paycheck
+		paycheck_amount = account_job.paycheck
 
 /datum/bank_account/Destroy()
 	if(add_to_accounts)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -16,6 +16,8 @@
 	var/withdrawDelay = 0
 
 /datum/bank_account/New(newname, job)
+	if(job == null)
+		add_to_accounts = FALSE
 	if(add_to_accounts)
 		SSeconomy.bank_accounts += src
 	account_holder = newname


### PR DESCRIPTION
# Zakładanie kont bankowych
fixes #221 

Pozwala na danie dostępu do ekonomii stacji (automaty itd.) latejoinerom którzy nie przylecieli na stację przez arrivals - na przykład przyjaznym ghost role. Jeżeli do identification console zostanie włożona karta która nie ma ustawionego konta (np ta pusta z box of spare ids), pojawia się opcja stworzenia nowego konta bankowego. 

Konto to nie znajduje się na globalnej liście kont, więc nie dostaje wypłaty - i nie da się jej ustawić - bo byłby to potencjalny exploit na ekonomię. Konto to będzie musiało być zasilane manualnie przez kredyty.

UI flow:
1. Karta bez konta włożona do id console - najpierw trzeba ją nazwać:
![obraz](https://user-images.githubusercontent.com/73129727/97197970-91a21900-17ae-11eb-8fd3-7f10abf19b9b.png)

2. Wpisano imię na kartę, można założyć konto:
![obraz](https://user-images.githubusercontent.com/73129727/97198066-b1d1d800-17ae-11eb-8ecd-9d48d84fe514.png)

3. Prompt w msglog dla obsługującego id console:
![obraz](https://user-images.githubusercontent.com/73129727/97198138-c57d3e80-17ae-11eb-8ff4-4acfde967726.png)

4. Karta gotowa do użytku:
![obraz](https://user-images.githubusercontent.com/73129727/97198211-dc239580-17ae-11eb-98cf-9ad2a127e3b2.png)


## Changelog
:cl:
add: dodano możliwośc tworzenia kont bankowych dla gości na stacji via identification console + spare ID
/:cl:

