### PR TITLE
Dodanie instrumentów do Kilostation

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -29044,6 +29044,7 @@
 "bdn" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
+/obj/item/instrument/piano_synth,
 /obj/item/storage/crayons,
 /obj/item/bikehorn/rubberducky,
 /obj/structure/sign/poster/contraband/clown{
@@ -45187,6 +45188,7 @@
 /area/crew_quarters/locker)
 "bJO" = (
 /obj/structure/table,
+/obj/item/instrument/random,
 /obj/item/storage/firstaid/regular,
 /obj/structure/cable,
 /turf/open/floor/plasteel,

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -245,6 +245,16 @@
 	throw_range = 15
 	hitsound = 'sound/items/bikehorn.ogg'
 
+/obj/item/instrument/random
+	name = "random instrument"
+	desc = "Uh oh!"
+
+/obj/item/instrument/random/Initialize()
+	..()
+	var/T = pick(subtypesof(/obj/item/instrument))
+	new T(loc)
+	return INITIALIZE_HINT_QDEL
+
 ///
 
 /obj/item/choice_beacon/music


### PR DESCRIPTION
Kilostation to jedyna mapa na której nie spawnują się żadne instrumenty muzyczne.

Zatem dorzucam klaunom syntezator i losowy instrument muzyczny w pokoju wspólnym (a wraz z nim obiekt losowego instrumentu)

PS. StrongDMM rządzi

## Changelog
:cl:
add: dodano instrumenty muzyczne do kilostation
/:cl: