### PR TITLE
Przywraca gender reasigment surgery

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3014,6 +3014,7 @@
 #include "code\modules\surgery\coronary_bypass.dm"
 #include "code\modules\surgery\dental_implant.dm"
 #include "code\modules\surgery\eye_surgery.dm"
+#include "code\modules\surgery\gender_reassignment.dm"
 #include "code\modules\surgery\healing.dm"
 #include "code\modules\surgery\helpers.dm"
 #include "code\modules\surgery\hepatectomy.dm"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -106,6 +106,13 @@
 		if(100 to 200)
 			. += "<span class='warning'>[t_He] [t_is] twitching ever so slightly.</span>"
 
+	//coin flip
+	if(gender_ambiguous) //someone fucked up a gender reassignment surgery
+		if (gender == MALE)
+			. += "[t_He] has a strange feminine quality to [t_him].\n"
+		else
+			. += "[t_He] has a strange masculine quality to [t_him].\n"
+
 	var/appears_dead = 0
 	if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
 		appears_dead = 1

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -52,6 +52,7 @@
 
 	var/list/datum/bioware = list()
 
+	var/gender_ambiguous = FALSE
 	var/creamed = FALSE //to use with creampie overlays
 	var/static/list/can_ride_typecache = typecacheof(list(/mob/living/carbon/human, /mob/living/simple_animal/slime, /mob/living/simple_animal/parrot))
 	var/lastpuke = 0

--- a/code/modules/surgery/gender_reassignment.dm
+++ b/code/modules/surgery/gender_reassignment.dm
@@ -1,0 +1,42 @@
+/datum/surgery/gender_reassignment
+	name = "gender reassignment"
+	target_mobtypes = list(/mob/living/carbon/human)
+	possible_locs = list(BODY_ZONE_PRECISE_GROIN)
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/reshape_genitals,
+		/datum/surgery_step/close
+		)
+
+//reshape_genitals
+/datum/surgery_step/reshape_genitals
+	name = "reshape genitals"
+	implements = list(/obj/item/scalpel = 100, /obj/item/hatchet = 50, TOOL_WIRECUTTER = 35)
+	time = 64
+
+/datum/surgery_step/reshape_genitals/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(target.gender == FEMALE)
+		user.visible_message("<span class='notice'>[user] begins to reshape [target]'s genitals to look more masculine.</span>")
+	else
+		user.visible_message("<span class='notice'>[user] begins to reshape [target]'s genitals to look more feminine.</span>")
+
+/datum/surgery_step/reshape_genitals/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target	//no type check, as that should be handled by the surgery
+	H.gender_ambiguous = 0
+	if(target.gender == FEMALE)
+		user.visible_message("<span class='notice'>[user] has made a man of [target]!</span>")
+		target.gender = MALE
+	else
+		user.visible_message("<span class='notice'>[user] has made a woman of [target]!</span>")
+		target.gender = FEMALE
+	target.regenerate_icons()
+	return 1
+
+/datum/surgery_step/reshape_genitals/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target
+	H.gender_ambiguous = 1
+	user.visible_message("<span class='warning'>[user] mutilates [target]'s genitals beyond the point of recognition!</span>")
+	target.gender = pick(MALE, FEMALE)
+	target.regenerate_icons()
+	return 1


### PR DESCRIPTION

## Changelog
:cl:
add: przywrócono gender reasigment surgery
/:cl:

![kisne](https://user-images.githubusercontent.com/72075763/101289024-134b8480-37fa-11eb-8cee-96ecf758cac9.png)

Przywraca najlepszą non-lethal kare dla bardzo niegrzecznych kosmoludzików, czyli zmiana płci 😃 

Procedura to;
- celowanie w krocze
- skalpel
- hemostat
- skalpel
- cautery
<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
