### PR TITLE
Nullcrate

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3258,4 +3258,6 @@
 #include "modular_aquila\modules\BLUESPACE_PIPE\code\construction.dm"
 #include "modular_aquila\modules\BLUESPACE_PIPE\code\bluespace_pipe.dm"
 #include "modular_aquila\modules\BLUESPACE_PIPE\code\design.dm"
+#include "modular_aquila\modules\NULLCRATE\code\packs.dm"
+#include "modular_aquila\modules\NULLCRATE\code\uplink_items.dm"
 // END_INCLUDE

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -115,6 +115,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/refund_amount = 0 // specified refund amount in case there needs to be a TC penalty for refunds.
 	var/refundable = FALSE
 	var/surplus = 100 // Chance of being included in the surplus crate.
+	var/surplus_nullcrates //Chance of being included in null crates. null = pull from surplus    AQUILA EDIT
 	var/cant_discount = FALSE
 	var/limited_stock = -1 //Setting this above zero limits how many times this item can be bought by the same traitor in a round, -1 is unlimited
 	var/list/include_modes = list() // Game modes to allow this item in.
@@ -583,6 +584,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/guardiancreator/tech
 	cost = 18
 	surplus = 10
+	surplus_nullcrates = 0 // Aquila Edit
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	player_minimum = 25
 	restricted = TRUE
@@ -747,6 +749,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 16
 	player_minimum = 20
 	surplus = 10
+	surplus_nullcrates = 0 // Aquila Edit
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/incursion)
 
 /datum/uplink_item/stealthy_weapons/radbow
@@ -1570,6 +1573,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/disk/nuclear/fake
 	cost = 1
 	surplus = 1
+	surplus_nullcrates = 0 // Aquila Edit
 
 /datum/uplink_item/device_tools/syndicate_teleporter
 	name = "Experimental Syndicate Teleporter"

--- a/modular_aquila/modules/NULLCRATE/code/packs.dm
+++ b/modular_aquila/modules/NULLCRATE/code/packs.dm
@@ -1,0 +1,36 @@
+/datum/supply_pack/emergency/syndicate
+	name = "NULL_ENTRY"
+	desc = "(#@&^$THIS PACKAGE CONTAINS 30TC WORTH OF SOME RANDOM SYNDICATE GEAR WE HAD LYING AROUND THE WAREHOUSE. GIVE EM HELL, OPERATIVE, BUT DON'T GET GREEDY- ORDER TOO MANY AND WE'LL BE SENDING OUR DEADLIEST ENFORCERS TO INVESTIGATE@&!*() "
+	hidden = TRUE
+	cost = 20000
+	contains = list()
+	crate_name = "emergency crate"
+	crate_type = /obj/structure/closet/crate/internals
+	dangerous = TRUE
+	var/beepsky_chance = -1
+	var/level = 1
+
+/datum/supply_pack/emergency/syndicate/fill(obj/structure/closet/crate/C)
+	var/crate_value = 30
+	var/list/uplink_items = get_uplink_items(SSticker.mode)
+	beepsky_chance += min(level, 5) //1% chance per crate an item will be replaced with a beepsky and the crate stops spawning items. Doesnt act as a hardcap, making nullcrates far riskier and less predictable
+	while(crate_value)
+		if(prob(beepsky_chance) && prob(50))
+			new /mob/living/simple_animal/bot/secbot/grievous/nullcrate(C)
+			crate_value = 0
+			beepsky_chance = 0
+			level += 1
+		var/category = pick(uplink_items)
+		var/item = pick(uplink_items[category])
+		var/datum/uplink_item/I = uplink_items[category][item]
+		if(!I.surplus_nullcrates || prob(100 - I.surplus_nullcrates))
+			continue
+		if(crate_value < I.cost)
+			continue
+		crate_value -= I.cost
+		new I.item(C)
+	var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
+	if(istype(loneop))
+		loneop.weight += 7
+		message_admins("a NULL_ENTRY crate has shipped, increasing the weight of the Lone Operative event to [loneop.weight]")
+		log_game("a NULL_ENTRY crate has shipped, increasing the weight of the Lone Operative event to [loneop.weight]")

--- a/modular_aquila/modules/NULLCRATE/code/uplink_items.dm
+++ b/modular_aquila/modules/NULLCRATE/code/uplink_items.dm
@@ -1,0 +1,4 @@
+/datum/uplink_item/New()
+	. = ..()
+	if(isnull(surplus_nullcrates))
+		surplus_nullcrates = surplus

--- a/modular_aquila/modules/NULLCRATE/readme.dm
+++ b/modular_aquila/modules/NULLCRATE/readme.dm
@@ -1,6 +1,6 @@
 ### Link do PRa:
 
-https://github.com/aq33/tgstation/pull/
+https://github.com/aq33/tgstation/pull/844
 
 ### ID:
 

--- a/modular_aquila/modules/NULLCRATE/readme.dm
+++ b/modular_aquila/modules/NULLCRATE/readme.dm
@@ -1,0 +1,18 @@
+### Link do PRa:
+
+https://github.com/aq33/tgstation/pull/
+
+### ID:
+
+ID: NULLCRATE
+
+### Oryginalny PR (jeśli istnieje):
+
+
+
+### Zmiany w plikach poza folderem "aquila":
+- code/modules/uplink/uplink_items.dm
+
+
+### Autorzy:
+Dejaku51


### PR DESCRIPTION
# O Pull Requeście
<!-- np zamyka jakiś issue, wtedy napisz "fixes #nn" gdzie nn to numer issue -->
Przywrócono nullcrate czyli skrzynke zawierającą rzeczy z uplinku. skrzynka dostępna w konsoli cargo po zemagowaniu
Kupowanie nullcrate zwiększa szanse na pojawienie się loneops
## Changelog
:cl:
add: Przywrócono Nullcrate
/:cl:

<!-- Oba :cl:'s są potrzebne żeby changelog działał! -->
